### PR TITLE
Preserve line breaks in Superhuman comments

### DIFF
--- a/superhuman_mail/comment.py
+++ b/superhuman_mail/comment.py
@@ -45,7 +45,7 @@ def _comment_id() -> str:
 
 
 def _build_html(text: str, mentions: list[dict[str, str]] | None = None) -> str:
-    escaped = html_mod.escape(text)
+    escaped = html_mod.escape(text.replace("\r\n", "\n").replace("\r", "\n"))
     if mentions:
         sorted_mentions = sorted(mentions, key=lambda m: len(m.get("fullName", m.get("email", ""))), reverse=True)
         for m in sorted_mentions:
@@ -59,8 +59,15 @@ def _build_html(text: str, mentions: list[dict[str, str]] | None = None) -> str:
             if email and email != name:
                 escaped = escaped.replace(f"@{html_mod.escape(email)}", tag)
 
-    paragraphs = escaped.split("\n\n")
-    body = "".join(f"<p>{p}</p>" for p in paragraphs if p.strip())
+    # HTML collapses literal newline characters inside a <p>, which made agent
+    # status comments appear as one wrapped wall of text in Superhuman. Keep
+    # blank lines as paragraph breaks and render single newlines explicitly.
+    paragraphs = re.split(r"\n[ \t]*\n+", escaped.strip("\n"))
+    rendered_paragraphs = []
+    for paragraph in paragraphs:
+        if paragraph.strip():
+            rendered_paragraphs.append(f"<p>{'<br />'.join(paragraph.splitlines())}</p>")
+    body = "".join(rendered_paragraphs)
     return f"<div>{body}</div>" if body else "<div><p></p></div>"
 
 

--- a/tests/test_comment_html.py
+++ b/tests/test_comment_html.py
@@ -1,0 +1,31 @@
+"""Tests for Superhuman comment HTML rendering."""
+from __future__ import annotations
+
+from superhuman_mail.comment import _build_html
+
+
+def test_comment_html_preserves_single_newlines_as_breaks():
+    html = _build_html("Summary:\n- one\n- two\n\nNext step:\nfollow up")
+
+    assert html == (
+        "<div>"
+        "<p>Summary:<br />- one<br />- two</p>"
+        "<p>Next step:<br />follow up</p>"
+        "</div>"
+    )
+
+
+def test_comment_html_normalizes_windows_newlines():
+    html = _build_html("Line one\r\nLine two\r\n\r\nLine three")
+
+    assert html == "<div><p>Line one<br />Line two</p><p>Line three</p></div>"
+
+
+def test_comment_html_keeps_escaping_and_mentions_with_line_breaks():
+    html = _build_html(
+        "Please review @Alice Example\nUse <real> data",
+        mentions=[{"email": "alice@example.com", "fullName": "Alice Example"}],
+    )
+
+    assert '<a data-mention="alice@example.com" data-name="Alice Example">@Alice Example</a>\u200b' in html
+    assert "<br />Use &lt;real&gt; data" in html


### PR DESCRIPTION
## Summary
- render single newlines in Superhuman comments as explicit `<br />` tags
- keep blank lines as paragraph breaks
- add tests for multiline and mentioned comments

## RCA
`comment._build_html` escaped the text and split only on double-newlines, leaving ordinary `\n` characters inside `<p>` tags. Browsers/Superhuman collapse those whitespace newlines, so Pinet status comments appeared as one dense wrapped paragraph.

## Validation
- `uv run --with pytest pytest`
