### PR TITLE
Make Superhuman sends lifecycle-safe and exactly attested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This safety release replaces ambiguous draft/send behavior with typed lifecycle,
 
 ### Breaking send changes
 
-- `shm send --confirm` now requires `--account`, `--attestation`, and `--approval-ref`
+- `shm send --confirm` now requires `--account`, `--attestation`, and an externally signed `--approval-receipt`; caller-supplied `--approval-ref` never authorizes
 - HTTP acceptance no longer returns unconditional `sent: true`
 - pending/backend-only/unknown/inconsistent possible-send outcomes exit `4`; only provider-confirmed immediate sends return sent success
 - customer sends have no raw-HTML or unattested fallback
@@ -20,7 +20,8 @@ This safety release replaces ambiguous draft/send behavior with typed lifecycle,
 - exact renderer attestation through the live Superhuman DraftModel/editor/BodyContent pipeline
 - post-grace second no-write renderer probe and complete payload/source/version/signature/attachment stale binding
 - signed, expiring local attestation artifacts and safe `shm attestation show` inspection
-- explicit approval-boundary output: `--approval-ref` is correlation only and unattended confirm is ineligible without an external issuer
+- `shm approval verify`, the `shm-approval-receipt/v1` Ed25519 contract, exact content-free approval bindings, and typed issuer/key/receipt state
+- atomic single-use receipt consumption in the same SQLite transaction as the only local POST claim
 - macOS native-window screenshot fallback for Electron CDP targets
 - adversarial tests for terminal DRAFT residue, optimistic SENT overlays, delayed completion, lost responses, local concurrency, stale payloads, attachment verification, privacy, and provider gating
 
@@ -30,7 +31,8 @@ This safety release replaces ambiguous draft/send behavior with typed lifecycle,
 - only an unambiguously linked immutable provider `SENT` message sets `sent: true`
 - local idempotency is explicitly scoped to cooperating processes sharing one journal; cross-machine/global exactly-once is not claimed
 - full attestation artifacts stay in `0700`/`0600` local storage; CLI inspection redacts message content and stable private provider IDs
-- Superhuman app+web renderer builds are code-allowlisted, non-idempotent probe traffic fails closed, and signing keys come only from Keychain
+- Superhuman app+web renderer builds are code-allowlisted, non-idempotent probe traffic fails closed, and attestation signing keys come only from Keychain
+- receipt trust roots cannot come from environment/user-writable files; absent external issuer trust disables confirm
 
 ## v0.2.1 — 2026-03-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This safety release replaces ambiguous draft/send behavior with typed lifecycle,
 
 - `shm send --confirm` now requires `--account`, `--attestation`, and `--approval-ref`
 - HTTP acceptance no longer returns unconditional `sent: true`
-- pending/backend-only/unknown outcomes exit `4`; only provider-confirmed immediate sends return sent success
+- pending/backend-only/unknown/inconsistent possible-send outcomes exit `4`; only provider-confirmed immediate sends return sent success
 - customer sends have no raw-HTML or unattested fallback
 
 ### Added
@@ -20,6 +20,7 @@ This safety release replaces ambiguous draft/send behavior with typed lifecycle,
 - exact renderer attestation through the live Superhuman DraftModel/editor/BodyContent pipeline
 - post-grace second no-write renderer probe and complete payload/source/version/signature/attachment stale binding
 - signed, expiring local attestation artifacts and safe `shm attestation show` inspection
+- explicit approval-boundary output: `--approval-ref` is correlation only and unattended confirm is ineligible without an external issuer
 - macOS native-window screenshot fallback for Electron CDP targets
 - adversarial tests for terminal DRAFT residue, optimistic SENT overlays, delayed completion, lost responses, local concurrency, stale payloads, attachment verification, privacy, and provider gating
 
@@ -29,7 +30,7 @@ This safety release replaces ambiguous draft/send behavior with typed lifecycle,
 - only an unambiguously linked immutable provider `SENT` message sets `sent: true`
 - local idempotency is explicitly scoped to cooperating processes sharing one journal; cross-machine/global exactly-once is not claimed
 - full attestation artifacts stay in `0700`/`0600` local storage; CLI inspection redacts message content and stable private provider IDs
-- Superhuman renderer versions are allowlisted and fail closed on drift
+- Superhuman app+web renderer builds are code-allowlisted, non-idempotent probe traffic fails closed, and signing keys come only from Keychain
 
 ## v0.2.1 — 2026-03-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## v0.3.0 — 2026-07-10
+
+This safety release replaces ambiguous draft/send behavior with typed lifecycle, local attempt reconciliation, and exact live-Superhuman render attestation.
+
+### Breaking send changes
+
+- `shm send --confirm` now requires `--account`, `--attestation`, and `--approval-ref`
+- HTTP acceptance no longer returns unconditional `sent: true`
+- pending/backend-only/unknown outcomes exit `4`; only provider-confirmed immediate sends return sent success
+- customer sends have no raw-HTML or unattested fallback
+
+### Added
+
+- canonical lifecycle/provenance classifier joining source wrappers, send jobs, and immutable provider messages
+- `shm draft status`, lifecycle-aware `draft read --active-only`, and `shm send status`
+- mandatory execute-time rejection for terminal, discarded, pending/scheduled, inconsistent, invalid-recipient, wrong-account, and empty-body drafts
+- private SQLite attempt journal with stable `superhuman_id`, one local POST claim, and reconcile-before-retry behavior
+- exact renderer attestation through the live Superhuman DraftModel/editor/BodyContent pipeline
+- post-grace second no-write renderer probe and complete payload/source/version/signature/attachment stale binding
+- signed, expiring local attestation artifacts and safe `shm attestation show` inspection
+- macOS native-window screenshot fallback for Electron CDP targets
+- adversarial tests for terminal DRAFT residue, optimistic SENT overlays, delayed completion, lost responses, local concurrency, stale payloads, attachment verification, privacy, and provider gating
+
+### Safety and scope
+
+- source-draft IDs, labels, timestamps, and HTTP 2xx are never outbound proof
+- only an unambiguously linked immutable provider `SENT` message sets `sent: true`
+- local idempotency is explicitly scoped to cooperating processes sharing one journal; cross-machine/global exactly-once is not claimed
+- full attestation artifacts stay in `0700`/`0600` local storage; CLI inspection redacts message content and stable private provider IDs
+- Superhuman renderer versions are allowlisted and fail closed on drift
+
 ## v0.2.1 — 2026-03-24
 
 This patch release includes all changes merged since `v0.2.0`.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ shm schema draft.forward
 
 `send --dry-run` is metadata/lifecycle validation only; it reports `send_eligible: false` until an exact live-Superhuman render is attested. `send --confirm` always reruns the renderer after the external grace period and posts only freshly probed bytes equal to approval.
 
-Only `state: sent_provider_confirmed` returns `sent: true`. Accepted/pending/unknown/backend-only outcomes exit `4`; rejected/failed outcomes exit `1`; provider-confirmed or explicitly scheduled outcomes exit `0`. The local journal prevents duplicate POSTs only among cooperating `shm` processes sharing one state directory—global exactly-once is not claimed.
+Only `state: sent_provider_confirmed` returns `sent: true`. Accepted/pending/unknown/backend-only or inconsistent possible-send outcomes exit `4`; definitely rejected/failed outcomes exit `1`; provider-confirmed or explicitly scheduled outcomes exit `0`. The local journal prevents duplicate POSTs only among cooperating `shm` processes sharing one state directory—global exactly-once is not claimed. `--approval-ref` is correlation only (`approval_verified: false`, `unattended_send_eligible: false`); unattended automation must hard-disable confirm until an external signed approval issuer exists.
 
 See [`docs/send-safety.md`](docs/send-safety.md) for renderer setup, lifecycle evidence, redaction, and retry rules.
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ shm comment discard <thread_id> <comment_id>
 shm send --dry-run <thread_id> <draft_id> --account owner@example.com
 shm draft attest-render <thread_id> <draft_id> --account owner@example.com --output ./private-preview [--window-id ID]
 shm attestation show <id-or-path> --account owner@example.com --thread-id <thread_id> --draft-id <draft_id>
-shm send --confirm <thread_id> <draft_id> --account owner@example.com --attestation <id-or-path> --approval-ref <opaque-ref> --wait 120
+shm approval verify <receipt.json> --attestation <id-or-path>
+shm send --confirm <thread_id> <draft_id> --account owner@example.com --attestation <id-or-path> --approval-receipt <receipt.json> --wait 120
 shm send status <thread_id> <draft_id> --account owner@example.com --wait 120
 
 # Diagnostics
@@ -152,9 +153,9 @@ shm schema draft.forward
 
 ### Strict send semantics
 
-`send --dry-run` is metadata/lifecycle validation only; it reports `send_eligible: false` until an exact live-Superhuman render is attested. `send --confirm` always reruns the renderer after the external grace period and posts only freshly probed bytes equal to approval.
+`send --dry-run` is metadata/lifecycle validation only; it reports `send_eligible: false` until an exact live-Superhuman render is attested. `send --confirm` requires an externally issued Ed25519 receipt bound to that exact attestation, reruns the renderer after the external grace period, atomically consumes the single-use receipt with the local POST claim, and posts only freshly probed matching bytes. Caller-supplied `--approval-ref` never authorizes.
 
-Only `state: sent_provider_confirmed` returns `sent: true`. Accepted/pending/unknown/backend-only or inconsistent possible-send outcomes exit `4`; definitely rejected/failed outcomes exit `1`; provider-confirmed or explicitly scheduled outcomes exit `0`. The local journal prevents duplicate POSTs only among cooperating `shm` processes sharing one state directory—global exactly-once is not claimed. `--approval-ref` is correlation only (`approval_verified: false`, `unattended_send_eligible: false`); unattended automation must hard-disable confirm until an external signed approval issuer exists.
+Only `state: sent_provider_confirmed` returns `sent: true`. Accepted/pending/unknown/backend-only or inconsistent possible-send outcomes exit `4`; definitely rejected/failed outcomes exit `1`; provider-confirmed or explicitly scheduled outcomes exit `0`. The local journal prevents duplicate POSTs only among cooperating trusted-executor processes sharing one state directory—global exactly-once is not claimed. Until an external issuer public key is pinned and the transport credentials are isolated in a trusted executor, confirm fails closed with `APPROVAL_TRUST_UNAVAILABLE`.
 
 See [`docs/send-safety.md`](docs/send-safety.md) for renderer setup, lifecycle evidence, redaction, and retry rules.
 
@@ -224,10 +225,11 @@ result = c.draft.share("19d001f35612a211", "draft00abc123")
 result = c.send.validate("19d001f35612a211", "draft00abc123", account="owner@example.com")
 attested = c.draft.attest_render("19d001f35612a211", "draft00abc123",
                                  account="owner@example.com", output_dir=Path("./private-preview"))
+receipt = c.approval.verify("receipt.json", attestation=attested["attestation_id"])
 result = c.send.execute("19d001f35612a211", "draft00abc123",
                         account="owner@example.com",
                         attestation=attested["attestation_id"],
-                        approval_ref="opaque-approval-reference")
+                        approval_receipt="receipt.json")
 ```
 
 All methods return the same envelope dict as the CLI.
@@ -276,11 +278,12 @@ pyproject.toml
 - `docs/superhuman-read-statuses.md` — read receipts, Recent Opens, and the thread userdata model
 - `docs/official-superhuman-mcp-beta.md` — notes on the official MCP beta
 - `docs/draft-lifecycle-render-attestation.md` — RCA and lifecycle/render-attestation design
-- `docs/send-safety.md` — lifecycle evidence, exact render attestation, reconciliation, and exit contracts
+- `docs/send-safety.md` — lifecycle evidence, exact render attestation, external approval, reconciliation, and exit contracts
+- `docs/approval-receipt-issuer-contract.md` / `approval-receipt-v1.schema.json` — trusted issuer/executor interface
 
 ## Safety
 
-- `send` is irreversible and requires exact attestation plus an opaque explicit-approval reference
+- `send` is irreversible and requires exact attestation plus an externally signed, short-lived, exact-binding approval receipt
 - execute-time lifecycle validation blocks terminal source-draft residue and existing pending/scheduled jobs
 - HTTP acceptance is pending, never proof of delivery; provider-confirmed immutable identity is required for `sent: true`
 - retries reuse one local attempt identity and reconcile before any further action

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is **not** an official SDK. It talks to Superhuman's private API and local 
 - **Drafts**: create reply, reply-all, forward, and compose drafts
 - **Draft management**: read, discard, attach files, share, and unshare drafts
 - **Comments**: post, read, and discard thread comments
-- **Send**: validate and send drafts with an explicit safety gate
+- **Send safety**: typed lifecycle, exact live-render attestation, local attempt reconciliation, and provider-confirmed completion
 - **Setup / doctor**: bootstrap config from the local Superhuman app and verify auth
 
 ## Install
@@ -55,6 +55,7 @@ export SUPERHUMAN_MAIL_CONFIG=/path/to/config.json
 
 - Superhuman desktop app installed and signed in
 - Python 3.11+
+- Node.js 22+ for the CDP exact-render probe
 - `cryptography` installed in the environment running `shm`
 
 ## Config
@@ -87,7 +88,7 @@ There is no alternate text/table mode. Humans can pipe to `jq`; agents always ge
 
 | Tier | Commands | Risk |
 |---|---|---|
-| **read** | `thread messages`, `thread userdata`, `thread list`, `thread search`, `opens`, `opens --recent`, `draft read`, `comment read`, `doctor`, `schema` | None |
+| **read** | `thread messages`, `thread userdata`, `thread list`, `thread search`, `opens`, `opens --recent`, `draft read`, `draft status`, `draft attest-render`, `attestation show`, `send --dry-run`, `send status`, `comment read`, `doctor`, `schema` | No mail mutation |
 | **write** | `setup`, `draft reply`, `draft reply-all`, `draft forward`, `draft compose`, `draft discard`, `draft attach`, `draft share`, `draft unshare`, `comment post`, `comment discard` | Reversible |
 | **irreversible** | `send` | Requires `--dry-run` or `--confirm` |
 
@@ -123,7 +124,8 @@ shm draft reply <thread_id> --body "Checking in" --scheduled-for "2026-03-26T09:
 shm draft compose --subject "Hi" --body "..." --to x@example.com --reminder "2026-04-01T09:00:00Z"
 
 # Read / manage drafts
-shm draft read <thread_id>
+shm draft read <thread_id> [--active-only] [--account email]
+shm draft status <thread_id> [--draft-id id] [--account email]
 shm draft discard <thread_id> <draft_id>
 shm draft attach <thread_id> <draft_id> ./report.pdf
 shm draft share <thread_id> <draft_id>
@@ -134,9 +136,12 @@ shm comment post <thread_id> --body "Please review"
 shm comment read <thread_id>
 shm comment discard <thread_id> <comment_id>
 
-# Send (validate first, then explicitly confirm)
-shm send --dry-run <thread_id> <draft_id>
-shm send --confirm <thread_id> <draft_id>
+# Send safety: lifecycle preflight → exact render → approval gate → confirm/status
+shm send --dry-run <thread_id> <draft_id> --account owner@example.com
+shm draft attest-render <thread_id> <draft_id> --account owner@example.com --output ./private-preview [--window-id ID]
+shm attestation show <id-or-path> --account owner@example.com --thread-id <thread_id> --draft-id <draft_id>
+shm send --confirm <thread_id> <draft_id> --account owner@example.com --attestation <id-or-path> --approval-ref <opaque-ref> --wait 120
+shm send status <thread_id> <draft_id> --account owner@example.com --wait 120
 
 # Diagnostics
 shm setup [--email someone@example.com]
@@ -145,9 +150,17 @@ shm schema
 shm schema draft.forward
 ```
 
+### Strict send semantics
+
+`send --dry-run` is metadata/lifecycle validation only; it reports `send_eligible: false` until an exact live-Superhuman render is attested. `send --confirm` always reruns the renderer after the external grace period and posts only freshly probed bytes equal to approval.
+
+Only `state: sent_provider_confirmed` returns `sent: true`. Accepted/pending/unknown/backend-only outcomes exit `4`; rejected/failed outcomes exit `1`; provider-confirmed or explicitly scheduled outcomes exit `0`. The local journal prevents duplicate POSTs only among cooperating `shm` processes sharing one state directory—global exactly-once is not claimed.
+
+See [`docs/send-safety.md`](docs/send-safety.md) for renderer setup, lifecycle evidence, redaction, and retry rules.
+
 ### Notes
 
-- `thread userdata` is intentionally marked **advanced**. Prefer purpose-built commands like `draft read`, `comment read`, or `opens` when possible.
+- `thread userdata` is intentionally marked **advanced**. Prefer purpose-built commands like `draft read`, `draft status`, `send status`, `comment read`, or `opens` when possible.
 - `thread list` and `thread search` support `--account` for multi-account setups.
 - `thread list` and `thread search` support `--fail-empty` to exit with code `3` on zero results.
 - All draft creation commands support smart-send flags: `--scheduled-for`, `--abort-on-reply`, `--reminder`, `--sensitivity-label-id`, `--sensitivity-tenant-id`. Use `shm schema draft.reply` for details.
@@ -186,6 +199,7 @@ Error classes:
 ## Python client
 
 ```python
+from pathlib import Path
 from superhuman_mail import Client
 
 c = Client()
@@ -206,9 +220,14 @@ result = c.draft.create_reply("19d001f35612a211", body="Following up",
 result = c.draft.create_compose(subject="Hi", body="Hello", to=["someone@example.com"])
 result = c.draft.share("19d001f35612a211", "draft00abc123")
 
-# Send
-result = c.send.validate("19d001f35612a211", "draft00abc123")
-result = c.send.execute("19d001f35612a211", "draft00abc123")
+# Send (strict exact-attested execution)
+result = c.send.validate("19d001f35612a211", "draft00abc123", account="owner@example.com")
+attested = c.draft.attest_render("19d001f35612a211", "draft00abc123",
+                                 account="owner@example.com", output_dir=Path("./private-preview"))
+result = c.send.execute("19d001f35612a211", "draft00abc123",
+                        account="owner@example.com",
+                        attestation=attested["attestation_id"],
+                        approval_ref="opaque-approval-reference")
 ```
 
 All methods return the same envelope dict as the CLI.
@@ -256,11 +275,15 @@ pyproject.toml
 - `docs/superhuman-api-endpoints.md` — reverse-engineered endpoint inventory
 - `docs/superhuman-read-statuses.md` — read receipts, Recent Opens, and the thread userdata model
 - `docs/official-superhuman-mcp-beta.md` — notes on the official MCP beta
-- `docs/draft-lifecycle-render-attestation.md` — RCA and proposed lifecycle/render-attestation design
+- `docs/draft-lifecycle-render-attestation.md` — RCA and lifecycle/render-attestation design
+- `docs/send-safety.md` — lifecycle evidence, exact render attestation, reconciliation, and exit contracts
 
 ## Safety
 
-- `send` is irreversible and intentionally requires `--dry-run` or `--confirm`
+- `send` is irreversible and requires exact attestation plus an opaque explicit-approval reference
+- execute-time lifecycle validation blocks terminal source-draft residue and existing pending/scheduled jobs
+- HTTP acceptance is pending, never proof of delivery; provider-confirmed immutable identity is required for `sent: true`
+- retries reuse one local attempt identity and reconcile before any further action
 - draft/comment/share operations are reversible
 - `shm doctor` verifies config, local DB, keychain, and auth before you rely on the CLI
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -60,7 +60,7 @@ Use this workflow every time:
 7. pass the opaque approval reference and attestation through the configured outbound send gate/grace period
 8. let the gate invoke `shm send --confirm ...`; then wait for `sent_provider_confirmed`
 
-Never treat draft timestamps, labels, HTTP acceptance, `sent_backend_confirmed`, or exit `4` as a completed send. Never create CRM/follow-up work until `provider_confirmed: true`.
+Never treat draft timestamps, labels, HTTP acceptance, `sent_backend_confirmed`, or exit `4` as a completed send. Never create CRM/follow-up work until `provider_confirmed: true`. `--approval-ref` is audit correlation, not technical authority; unattended agents must not invoke `--confirm` (`unattended_send_eligible: false`).
 
 ## Command surface
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -19,7 +19,8 @@ This is an unofficial, reverse-engineered integration — not an official Superh
 `shm` requires:
 1. Superhuman desktop app installed and signed in
 2. Python 3.11+
-3. `cryptography` available in the environment running `shm`
+3. Node.js 22+ for exact live-render probing
+4. `cryptography` available in the environment running `shm`
 
 ## Setup
 
@@ -47,15 +48,19 @@ If `shm doctor` fails, make sure Superhuman is running and signed in, then rerun
 
 ## Core safety rule
 
-**Never send without explicit user approval.**
+**Never send without explicit user approval and an exact live-render attestation.**
 
 Use this workflow every time:
 1. create or inspect the draft
-2. run `shm send --dry-run ...`
-3. show the output to the user
-4. only run `shm send --confirm ...` after explicit approval
+2. run lifecycle preflight: `shm send --dry-run ... --account EMAIL`
+3. open that exact draft in a CDP-enabled Superhuman app without editing it
+4. run `shm draft attest-render ... --account EMAIL --output PRIVATE_DIR`
+5. verify/display only `shm attestation show ...` safe metadata and exact-render screenshots
+6. show the complete intended message to the user and obtain explicit approval
+7. pass the opaque approval reference and attestation through the configured outbound send gate/grace period
+8. let the gate invoke `shm send --confirm ...`; then wait for `sent_provider_confirmed`
 
-Everything else in `shm` is either read-only or reversible.
+Never treat draft timestamps, labels, HTTP acceptance, `sent_backend_confirmed`, or exit `4` as a completed send. Never create CRM/follow-up work until `provider_confirmed: true`.
 
 ## Command surface
 
@@ -104,7 +109,9 @@ echo "body" | shm draft reply <thread_id> --body - [smart-send flags]
 shm draft reply-all <thread_id> --body "..." [--body-html html] [smart-send flags]
 shm draft forward <thread_id> --body "..." [--to email ...] [--cc email ...] [--bcc email ...] [--body-html html] [smart-send flags]
 shm draft compose --subject "..." --body "..." [--to email ...] [--cc email ...] [--bcc email ...] [--body-html html] [smart-send flags]
-shm draft read <thread_id> [--draft-id id]
+shm draft read <thread_id> [--draft-id id] [--active-only] [--account email]
+shm draft status <thread_id> [--draft-id id] [--account email]
+shm draft attest-render <thread_id> <draft_id> --account email --output private-dir [--window-id id]
 shm draft discard <thread_id> <draft_id>
 shm draft attach <thread_id> <draft_id> <file> [--content-type mime]
 shm draft share <thread_id> <draft_id> [--name name]
@@ -132,8 +139,11 @@ shm comment discard <thread_id> <comment_id>
 ### Send / misc
 
 ```bash
-shm send --dry-run <thread_id> <draft_id>
-shm send --confirm <thread_id> <draft_id>
+shm send --dry-run <thread_id> <draft_id> --account email
+shm attestation show <id-or-path> --account email --thread-id <thread_id> --draft-id <draft_id>
+shm send status <thread_id> <draft_id> --account email [--wait seconds]
+# The configured send gate invokes this only after explicit approval + grace:
+shm send --confirm <thread_id> <draft_id> --account email --attestation <id-or-path> --approval-ref <opaque-ref> [--wait seconds]
 shm setup [--config path] [--email address]
 shm doctor
 shm schema [command]
@@ -154,14 +164,12 @@ Then:
 ```bash
 shm thread messages <thread_id>
 shm draft reply <thread_id> --body "..."
-shm send --dry-run <thread_id> <draft_id>
+shm send --dry-run <thread_id> <draft_id> --account owner@example.com
+shm draft attest-render <thread_id> <draft_id> --account owner@example.com --output ./private-preview
+shm attestation show <attestation_id> --account owner@example.com --thread-id <thread_id> --draft-id <draft_id>
 ```
 
-After the user explicitly approves:
-
-```bash
-shm send --confirm <thread_id> <draft_id>
-```
+After the user explicitly approves, route the attestation ID and opaque approval reference through the configured outbound send gate. Do not invoke direct transport outside that gate. Reconcile with `shm send status ...` until provider-confirmed.
 
 ### 2. Get read receipts / recent opens
 
@@ -261,7 +269,9 @@ shm draft reply 19c76b5e86217b7b --body "Thanks — following up here."
 shm draft share 19c76b5e86217b7b draft00abc123
 
 # Safe send flow
-shm send --dry-run 19c76b5e86217b7b draft00abc123
-# ... wait for explicit approval ...
-shm send --confirm 19c76b5e86217b7b draft00abc123
+shm send --dry-run 19c76b5e86217b7b draft00abc123 --account owner@example.com
+shm draft attest-render 19c76b5e86217b7b draft00abc123 --account owner@example.com --output ./private-preview
+shm attestation show ATTESTATION_ID --account owner@example.com --thread-id 19c76b5e86217b7b --draft-id draft00abc123
+# ... show exact result, obtain explicit approval, then use configured send gate ...
+shm send status 19c76b5e86217b7b draft00abc123 --account owner@example.com --wait 120
 ```

--- a/SKILL.md
+++ b/SKILL.md
@@ -56,11 +56,12 @@ Use this workflow every time:
 3. open that exact draft in a CDP-enabled Superhuman app without editing it
 4. run `shm draft attest-render ... --account EMAIL --output PRIVATE_DIR`
 5. verify/display only `shm attestation show ...` safe metadata and exact-render screenshots
-6. show the complete intended message to the user and obtain explicit approval
-7. pass the opaque approval reference and attestation through the configured outbound send gate/grace period
-8. let the gate invoke `shm send --confirm ...`; then wait for `sent_provider_confirmed`
+6. show the complete intended message to the user through the trusted approval broker
+7. obtain its short-lived Ed25519 receipt bound to the exact `approval_binding`
+8. verify it with `shm approval verify RECEIPT --attestation ID`
+9. let the trusted executor run the outbound gate/grace period and `shm send --confirm ... --approval-receipt RECEIPT`; then wait for `sent_provider_confirmed`
 
-Never treat draft timestamps, labels, HTTP acceptance, `sent_backend_confirmed`, or exit `4` as a completed send. Never create CRM/follow-up work until `provider_confirmed: true`. `--approval-ref` is audit correlation, not technical authority; unattended agents must not invoke `--confirm` (`unattended_send_eligible: false`).
+Never treat draft timestamps, labels, HTTP acceptance, `sent_backend_confirmed`, or exit `4` as a completed send. Never create CRM/follow-up work until `provider_confirmed: true`. Caller-supplied `--approval-ref` never authorizes. Until a trusted issuer root and credential-isolated executor are deployed, confirm must fail closed and unattended agents must not have Superhuman transport credentials.
 
 ## Command surface
 
@@ -141,9 +142,10 @@ shm comment discard <thread_id> <comment_id>
 ```bash
 shm send --dry-run <thread_id> <draft_id> --account email
 shm attestation show <id-or-path> --account email --thread-id <thread_id> --draft-id <draft_id>
+shm approval verify <receipt.json> --attestation <id-or-path>
 shm send status <thread_id> <draft_id> --account email [--wait seconds]
-# The configured send gate invokes this only after explicit approval + grace:
-shm send --confirm <thread_id> <draft_id> --account email --attestation <id-or-path> --approval-ref <opaque-ref> [--wait seconds]
+# The trusted executor invokes this only with an externally signed exact receipt:
+shm send --confirm <thread_id> <draft_id> --account email --attestation <id-or-path> --approval-receipt <receipt.json> [--wait seconds]
 shm setup [--config path] [--email address]
 shm doctor
 shm schema [command]
@@ -169,7 +171,7 @@ shm draft attest-render <thread_id> <draft_id> --account owner@example.com --out
 shm attestation show <attestation_id> --account owner@example.com --thread-id <thread_id> --draft-id <draft_id>
 ```
 
-After the user explicitly approves, route the attestation ID and opaque approval reference through the configured outbound send gate. Do not invoke direct transport outside that gate. Reconcile with `shm send status ...` until provider-confirmed.
+After the user explicitly approves, the external broker issues a single-use receipt for the attestation's exact binding. Verify it read-only, then let the credential-isolated trusted executor route the attestation and receipt through the outbound send gate. Do not invoke local/raw transport outside that boundary. Reconcile with `shm send status ...` until provider-confirmed.
 
 ### 2. Get read receipts / recent opens
 

--- a/docs/approval-receipt-issuer-contract.md
+++ b/docs/approval-receipt-issuer-contract.md
@@ -1,0 +1,151 @@
+# External approval receipt issuer contract
+
+Status: **core verifier implemented; external issuer not yet deployed**  
+Receipt schema: `shm-approval-receipt/v1`  
+JSON Schema: [`approval-receipt-v1.schema.json`](approval-receipt-v1.schema.json)
+
+## Security boundary
+
+The unattended worker is untrusted. It may choose CLI arguments, environment variables, paths, payloads, and process timing. It must not possess:
+
+- the receipt issuer's Ed25519 private key;
+- a writable approval trust root;
+- Superhuman write/session credentials outside the trusted executor;
+- a local/raw transport fallback that bypasses receipt verification;
+- an API that signs caller-provided bytes.
+
+The issuer belongs in `gugu91/extensions`' `slack-bridge` / durable `broker-core` state, under a separate hardened principal or service. Core `superhuman-mail` contains verification and atomic consumption only. Until a trust root is release-pinned or installed as a root-owned non-writable system file, `shm send --confirm` fails with `APPROVAL_TRUST_UNAVAILABLE`.
+
+A signed receipt is necessary but not sufficient if the worker retains raw Superhuman credentials. Production must run receipt verification, atomic consumption, and transport in a broker-owned/root-owned or remote trusted executor. The worker may submit a request to that executor but cannot patch it or extract its credentials.
+
+## Issuer API shape
+
+The trusted broker exposes semantic operations only:
+
+1. `approval.create(pending_request)`
+2. `approval.status(request_id)`
+3. `approval.cancel(request_id)`
+
+It never exposes `sign(bytes)`, private-key export, arbitrary approver selection, or caller-controlled trust-root configuration.
+
+`approval.create` accepts the content-free `approval_binding` returned by:
+
+```bash
+shm attestation show ID_OR_PATH --account EMAIL --thread-id THREAD --draft-id DRAFT
+```
+
+The binding covers:
+
+- action and provider;
+- immutable account, account email, thread, and draft hashes;
+- attestation ID and exact outgoing fingerprint;
+- complete outgoing-payload hash;
+- From/To/Cc/Bcc envelope hash;
+- renderer-build and screenshot-set hashes;
+- reserved send-identity hash;
+- delay and scheduled-send hash.
+
+The broker records the request, random nonce, ≤5-minute expiry, expected Thomas Slack principal, and approval presentation atomically before prompting. The human presentation must show the complete intended recipients, subject, body/render, attachments, and scheduling behavior. Uploaded/rendered evidence must hash to the server-recorded pending request; caller labels or summaries are not authoritative.
+
+## Authenticated decision
+
+The issuer directly consumes an authenticated Slack event from Thomas (`U0AF5S3LQ5C`) tied to one pending request. It must verify workspace, channel/thread, Slack event/message ID, principal, exact approval keyword, pending state, nonce, and expiry. It then atomically changes `pending -> approved` once and signs only the server-constructed receipt.
+
+Rejections, cancellations, duplicate decisions, late events, edited/deleted approval messages, or events from another principal never produce a receipt. The durable broker state owns TTL, nonce, decision, and audit history.
+
+## Canonical receipt and signature
+
+The receipt has no optional or extra fields. Core canonicalization is UTF-8 JSON with sorted keys, compact separators, and Unicode emitted directly (`ensure_ascii=false`).
+
+1. Build all fields except `receipt_id` and `signature`.
+2. `receipt_id = "sha256:" + SHA256(canonical_json(content)).hex()`.
+3. Add `receipt_id`.
+4. `signature = "ed25519:" + base64url_no_padding(Ed25519.sign(canonical_json(receipt_without_signature)))`.
+
+`issued_at` and `expires_at` are UTC RFC 3339 timestamps. `expires_at - issued_at` must be positive and at most five minutes. `nonce` has at least 128 bits of entropy.
+
+The approver object is:
+
+```json
+{
+  "principal": "slack:U0AF5S3LQ5C",
+  "approval_event_id": "<immutable authenticated Slack event/message ID>"
+}
+```
+
+The private key stays in the issuer service. Core pins only its public key and exact `issuer`/`key_id`/allowed-approver tuple. Environment variables and user-writable files cannot add or replace roots.
+
+## Core verification and consumption
+
+Read-only verification:
+
+```bash
+shm approval verify RECEIPT.json --attestation ID_OR_PATH
+```
+
+Strict send:
+
+```bash
+shm send --confirm THREAD DRAFT \
+  --account EMAIL \
+  --attestation ID_OR_PATH \
+  --approval-receipt RECEIPT.json \
+  --cdp-url http://127.0.0.1:9222 \
+  --window-id WINDOW_ID \
+  --wait 120
+```
+
+Core verifies schema, canonical ID, pinned issuer/key, Ed25519 signature, authorized approver, not-before/expiry/max TTL, action/provider, and byte-exact attestation binding. It performs the mandatory second renderer probe. Only then does one SQLite `BEGIN IMMEDIATE` transaction:
+
+1. recheck receipt expiry;
+2. reject a previously consumed receipt ID;
+3. insert the immutable receipt-consumption row;
+4. change the exact attempt from `prepared/post_count=0` to `posting/post_count=1`.
+
+A crash cannot commit receipt consumption without the POST claim or vice versa. After the claim, retry is reconciliation-only. Receipt consumption is retained even when old terminal attempts are purged.
+
+## Typed result contract
+
+Before receipt verification:
+
+```json
+{
+  "approval_authority": "external_receipt_required",
+  "approval_verified": false,
+  "approval_consumed": false,
+  "unattended_send_eligible": false
+}
+```
+
+For a verified attempt:
+
+```json
+{
+  "approval_authority": "external_ed25519_receipt_v1",
+  "approval_verified": true,
+  "approval_consumed": true,
+  "approval_receipt_id": "sha256:...",
+  "approval_issuer": "...",
+  "approval_key_id": "...",
+  "unattended_send_eligible": false,
+  "trusted_executor_required": true
+}
+```
+
+`sent: true` still requires independent provider confirmation. Receipt verification authorizes exactly one attempt; it does not prove delivery.
+
+## Required adversarial proof before rollout
+
+- caller-invented opaque ref cannot authorize;
+- absent/unpinned/caller-substituted trust roots fail;
+- forged signature and unknown issuer/key fail;
+- unauthorized Slack principal/event fails at issuer and verifier;
+- edited receipt or extra fields fail;
+- wrong account/thread/draft/action/provider fail;
+- changed recipient, body, attachment, renderer, screenshot, delay, schedule, or send identity fail;
+- future, expired, zero/negative, and >5-minute lifetimes fail;
+- sequential and concurrent replay fail;
+- receipt expiry between verify and claim fails inside the transaction;
+- signal/crash cannot split consume from claim;
+- worker process descendants cannot access issuer key or Superhuman transport credentials;
+- only the exact approved synthetic test reaches one POST and provider-confirmed completion.

--- a/docs/approval-receipt-v1.schema.json
+++ b/docs/approval-receipt-v1.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.nexcade.ai/superhuman-mail/approval-receipt-v1.schema.json",
+  "title": "Superhuman exact-send approval receipt v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "receipt_id",
+    "issuer",
+    "key_id",
+    "issued_at",
+    "expires_at",
+    "nonce",
+    "approver",
+    "action",
+    "provider",
+    "binding",
+    "signature"
+  ],
+  "properties": {
+    "schema": { "const": "shm-approval-receipt/v1" },
+    "receipt_id": { "$ref": "#/$defs/sha256" },
+    "issuer": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "key_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "issued_at": { "type": "string", "format": "date-time" },
+    "expires_at": { "type": "string", "format": "date-time" },
+    "nonce": { "type": "string", "minLength": 16, "maxLength": 256 },
+    "approver": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["principal", "approval_event_id"],
+      "properties": {
+        "principal": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "approval_event_id": { "type": "string", "minLength": 1, "maxLength": 256 }
+      }
+    },
+    "action": { "const": "superhuman.send" },
+    "provider": { "const": "superhuman" },
+    "binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action",
+        "provider",
+        "account_provider_user_id_sha256",
+        "account_email_sha256",
+        "thread_id_sha256",
+        "draft_id_sha256",
+        "attestation_id",
+        "outgoing_fingerprint",
+        "outgoing_payload_sha256",
+        "recipient_envelope_sha256",
+        "renderer_build_sha256",
+        "screenshot_set_sha256",
+        "send_identity_sha256",
+        "delay_seconds",
+        "scheduled_for_sha256"
+      ],
+      "properties": {
+        "action": { "const": "superhuman.send" },
+        "provider": { "const": "superhuman" },
+        "account_provider_user_id_sha256": { "$ref": "#/$defs/sha256" },
+        "account_email_sha256": { "$ref": "#/$defs/sha256" },
+        "thread_id_sha256": { "$ref": "#/$defs/sha256" },
+        "draft_id_sha256": { "$ref": "#/$defs/sha256" },
+        "attestation_id": { "$ref": "#/$defs/sha256" },
+        "outgoing_fingerprint": { "$ref": "#/$defs/sha256" },
+        "outgoing_payload_sha256": { "$ref": "#/$defs/sha256" },
+        "recipient_envelope_sha256": { "$ref": "#/$defs/sha256" },
+        "renderer_build_sha256": { "$ref": "#/$defs/sha256" },
+        "screenshot_set_sha256": { "$ref": "#/$defs/sha256" },
+        "send_identity_sha256": { "$ref": "#/$defs/sha256" },
+        "delay_seconds": { "type": "integer", "minimum": 0 },
+        "scheduled_for_sha256": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "signature": {
+      "type": "string",
+      "pattern": "^ed25519:[A-Za-z0-9_-]+={0,2}$"
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    }
+  }
+}

--- a/docs/send-safety.md
+++ b/docs/send-safety.md
@@ -103,7 +103,7 @@ shm attestation show ID_OR_PATH \
   --draft-id DRAFT
 ```
 
-The inspector verifies canonical ID/HMAC, expiry, and optional binding. It exposes counts, booleans, renderer versions, screenshot hashes/paths, and the overall fingerprint only. Valid-but-expired artifacts return `usable: false`; tamper or binding mismatch fails.
+The inspector verifies canonical ID/HMAC, screenshot hashes, expiry, and optional binding. It exposes counts, booleans (including `editor_normalized_changed`), renderer versions, screenshot hashes/paths, and the overall fingerprint only. Valid-but-expired artifacts return `usable: false`; tamper or binding mismatch fails.
 
 ### 4. Grace period and strict execution
 
@@ -172,7 +172,8 @@ These environment variables exist for controlled rollout/testing:
 - `SHM_STATE_DIR`
 - `SHM_RENDERER_CDP_URL`
 - `SHM_RENDERER_WINDOW_ID`
-- `SHM_RENDERER_ALLOW_VERSIONS`
+- `SHM_RENDERER_ALLOW_BUILDS` (`APP_VERSION@WEB_VERSION`; production rollout override)
+- `SHM_RENDERER_ALLOW_VERSIONS` (web-only fixture/testing override)
 - `SHM_ATTESTATION_KEY` (tests only; do not use as a production secret path)
 
 A new Superhuman code version fails closed until its renderer contract and non-sending E2E are reviewed.

--- a/docs/send-safety.md
+++ b/docs/send-safety.md
@@ -57,7 +57,7 @@ It rejects terminal, discarded, already pending/scheduled, contradictory, invali
 
 ### 2. Open the exact draft in a CDP-enabled Superhuman app
 
-The renderer adapter never navigates or types. The exact draft must already be visible and clean in Superhuman. On macOS, launch the app with CDP only after safely closing any existing instance:
+The renderer adapter never navigates or types. It accepts loopback-local CDP endpoints only. The exact draft must already be visible and clean in Superhuman. On macOS, launch the app with CDP only after safely closing any existing instance:
 
 ```bash
 open -a "Superhuman" --args --remote-debugging-port=9222
@@ -84,9 +84,10 @@ The adapter:
 - uses an ephemeral clone and Superhuman's live `MessageModel.getDraftHtmlBody()` path, which invokes `OutgoingMessage.fromDraft()` / `BodyContent.generateForOutgoingMessage()`;
 - reserves one `superhuman_id` for approval, second probe, POST, and reconciliation;
 - constructs the allowlisted build's exact `toJsonRequest()` envelope contract around those renderer-produced HTML bytes;
+- mirrors the current build's reminder behavior: reminder stays on the persisted, fingerprint-bound draft and is not copied into `toJsonRequest()`;
 - rejects inline signature uploads that cannot be materialized read-only;
 - captures the compose view and a network-disabled rendering of the exact outgoing HTML;
-- observes network requests and rejects prohibited send/write/upload/comment/cancel/postpone traffic;
+- observes network requests and fails closed on every non-idempotent request except an explicit read-only POST allowlist;
 - re-reads the server snapshot and history after rendering;
 - signs an expiring canonical artifact with a Keychain-held HMAC key.
 
@@ -131,21 +132,34 @@ Immediately before POST, `shm`:
 
 There is no unattested fallback for customer mail.
 
+## Approval authority boundary
+
+`--approval-ref` is audit correlation only. Core `shm` does not verify that the reference was issued by a human or an independent authority, and its result says:
+
+```text
+approval_authority: correlation_only
+approval_verified: false
+unattended_send_eligible: false
+```
+
+Therefore unattended automation must hard-disable `--confirm`. An operator may invoke a send only after the full message has been explicitly approved and through the external 60-second `send-gate`. A future unattended path requires a signed, single-use capability from an issuer whose signing key is unavailable to the worker; same-process CLI arguments, environment variables, or same-UID files are not an approval trust boundary. `shm attestation show` verifies render integrity, not human approval.
+
 ## Result and exit contract
 
 Send/status data includes:
 
 ```text
-state, accepted, sent, provider_confirmed, outbound_evidence
+state, post_claimed, accepted, sent, provider_confirmed, outbound_evidence
 attempt_id, attestation_id, superhuman_id, provider_message_id
+approval_authority, approval_verified, unattended_send_eligible
 idempotency_scope, lifecycle
 ```
 
 Exit codes:
 
 - `0`: immutable provider-confirmed send, or an explicitly scheduled job;
-- `1`: rejected, tampered/stale attestation, terminal failure, or lifecycle inconsistency;
-- `4`: accepted/pending/unknown/backend-only after the requested wait.
+- `1`: rejected, tampered/stale attestation, or definitely terminal failure;
+- `4`: pending/unknown/backend-only or inconsistent possible-send evidence after the requested wait.
 
 Follow-up/CRM automation must consume only `provider_confirmed: true` / `state: sent_provider_confirmed`.
 
@@ -161,6 +175,8 @@ idempotency_scope: local_cooperating_processes
 
 Global exactly-once requires a vendor idempotency key or compare-and-set send contract.
 
+`post_claimed` means the local exactly-once journal irrevocably claimed its single POST slot. `accepted` means HTTP 2xx or later backend/provider lifecycle evidence proves the server accepted the request; a pre-connect/network exception can therefore be `post_claimed: true, accepted: false`.
+
 After a network timeout, reset, or HTTP conflict, `shm` reconciles the same attempt. It never automatically posts again after the pre-network claim. An unresolved outcome remains `unknown`/pending and exits 4.
 
 ## Private state and test controls
@@ -172,8 +188,5 @@ These environment variables exist for controlled rollout/testing:
 - `SHM_STATE_DIR`
 - `SHM_RENDERER_CDP_URL`
 - `SHM_RENDERER_WINDOW_ID`
-- `SHM_RENDERER_ALLOW_BUILDS` (`APP_VERSION@WEB_VERSION`; production rollout override)
-- `SHM_RENDERER_ALLOW_VERSIONS` (web-only fixture/testing override)
-- `SHM_ATTESTATION_KEY` (tests only; do not use as a production secret path)
 
 A new Superhuman code version fails closed until its renderer contract and non-sending E2E are reviewed.

--- a/docs/send-safety.md
+++ b/docs/send-safety.md
@@ -1,0 +1,178 @@
+# Send lifecycle, exact render attestation, and reconciliation
+
+`shm` v0.3 fails closed around three distinct questions:
+
+1. **Is this source draft active and valid?**
+2. **Are the exact live-Superhuman outgoing bytes the ones a person approved?**
+3. **Did an immutable provider message linked to this attempt actually appear?**
+
+A draft timestamp, `DRAFT`/`SENT` presentation label, send-job acceptance, or HTTP 2xx is not by itself proof that mail left the account.
+
+## Canonical lifecycle
+
+```text
+active_draft
+scheduled
+send_requested
+send_pending_undo
+send_failed
+send_aborted
+discarded
+sent_backend_confirmed
+sent_provider_confirmed
+inconsistent
+```
+
+Only `sent_provider_confirmed` sets both `sent: true` and `outbound_evidence: true`. It requires an immutable provider `SENT` message linked through the completed job's exact message ID, or through both source-draft and persisted Superhuman attempt IDs. A nearby sent message on the same thread never qualifies.
+
+Source drafts may retain a raw `DRAFT` label after sending. Conversely, Superhuman may overlay `SENT` while an optimistic, undoable, or failed job exists. Use the classifier, not either label in isolation.
+
+Read lifecycle without sending:
+
+```bash
+shm draft status THREAD --draft-id DRAFT --account owner@example.com
+shm draft read THREAD --active-only --account owner@example.com
+shm send status THREAD DRAFT --account owner@example.com --wait 120
+```
+
+## Strict workflow
+
+### 1. Metadata/lifecycle preflight
+
+```bash
+shm send --dry-run THREAD DRAFT --account owner@example.com
+```
+
+This is read-only. A successful metadata preflight still returns:
+
+```json
+{
+  "sendable": true,
+  "send_eligible": false,
+  "render_attested": false
+}
+```
+
+It rejects terminal, discarded, already pending/scheduled, contradictory, invalid-recipient, wrong-account, and empty-body drafts. Empty subjects require explicit binding in an exact attestation.
+
+### 2. Open the exact draft in a CDP-enabled Superhuman app
+
+The renderer adapter never navigates or types. The exact draft must already be visible and clean in Superhuman. On macOS, launch the app with CDP only after safely closing any existing instance:
+
+```bash
+open -a "Superhuman" --args --remote-debugging-port=9222
+```
+
+A Pi/macOS automation caller may supply the visible Superhuman `windowId` for native screenshot fallback when Electron's `Page.captureScreenshot` stalls.
+
+### 3. Create exact render attestation
+
+```bash
+shm draft attest-render THREAD DRAFT \
+  --account owner@example.com \
+  --output ./private-preview \
+  --cdp-url http://127.0.0.1:9222 \
+  --window-id WINDOW_ID \
+  --delay 20
+```
+
+The adapter:
+
+- locates the exact live `DraftModel`, editor, account, and view state through React fibers;
+- requires a non-dirty model matching the server source snapshot;
+- reads `getHTMLSafe()` from Superhuman's editor;
+- uses an ephemeral clone and Superhuman's live `MessageModel.getDraftHtmlBody()` path, which invokes `OutgoingMessage.fromDraft()` / `BodyContent.generateForOutgoingMessage()`;
+- reserves one `superhuman_id` for approval, second probe, POST, and reconciliation;
+- constructs the allowlisted build's exact `toJsonRequest()` envelope contract around those renderer-produced HTML bytes;
+- rejects inline signature uploads that cannot be materialized read-only;
+- captures the compose view and a network-disabled rendering of the exact outgoing HTML;
+- observes network requests and rejects prohibited send/write/upload/comment/cancel/postpone traffic;
+- re-reads the server snapshot and history after rendering;
+- signs an expiring canonical artifact with a Keychain-held HMAC key.
+
+The outgoing screenshot is supporting evidence for the exact transport HTML. It is **not** a claim about Gmail, Outlook, or another recipient client's CSS. Controlled test-mailbox transport remains required before claiming recipient-client equivalence.
+
+The CLI summary does not print message content, recipient addresses, subject, signature content, provider-user ID, or reserved send identity. The full private artifact is written under a `0700` directory as a `0600` file.
+
+Inspect safely by ID or path:
+
+```bash
+shm attestation show ID_OR_PATH \
+  --account owner@example.com \
+  --thread-id THREAD \
+  --draft-id DRAFT
+```
+
+The inspector verifies canonical ID/HMAC, expiry, and optional binding. It exposes counts, booleans, renderer versions, screenshot hashes/paths, and the overall fingerprint only. Valid-but-expired artifacts return `usable: false`; tamper or binding mismatch fails.
+
+### 4. Grace period and strict execution
+
+An external gate displays the safe attestation summary, records an opaque approval reference, and runs its grace period. It then invokes:
+
+```bash
+shm send --confirm THREAD DRAFT \
+  --account owner@example.com \
+  --attestation ID_OR_PATH \
+  --approval-ref OPAQUE_REFERENCE \
+  --delay 20 \
+  --wait 120
+```
+
+Immediately before POST, `shm`:
+
+1. reruns authoritative lifecycle/envelope/body preflight;
+2. verifies account, artifact signature, expiry, thread/draft, approved delay, and source history;
+3. creates or resumes one local attempt identity;
+4. runs a second no-write live-Superhuman renderer probe with the reserved ID;
+5. requires the complete exact fingerprint and outgoing payload bytes to equal approval;
+6. atomically claims the only local POST before network I/O;
+7. posts the freshly probed exact payload;
+8. reconciles userdata/provider evidence without minting another identity.
+
+There is no unattested fallback for customer mail.
+
+## Result and exit contract
+
+Send/status data includes:
+
+```text
+state, accepted, sent, provider_confirmed, outbound_evidence
+attempt_id, attestation_id, superhuman_id, provider_message_id
+idempotency_scope, lifecycle
+```
+
+Exit codes:
+
+- `0`: immutable provider-confirmed send, or an explicitly scheduled job;
+- `1`: rejected, tampered/stale attestation, terminal failure, or lifecycle inconsistency;
+- `4`: accepted/pending/unknown/backend-only after the requested wait.
+
+Follow-up/CRM automation must consume only `provider_confirmed: true` / `state: sent_provider_confirmed`.
+
+## Idempotency scope
+
+The SQLite attempt journal lives in one canonical private per-user state directory. A unique `(immutable_provider_user_id, draft_id)` row and `BEGIN IMMEDIATE` claim guarantee one POST for cooperating `shm` processes sharing that journal.
+
+This does **not** serialize another host, another state directory, the native Superhuman UI, or an uncooperative caller. Outputs therefore say:
+
+```text
+idempotency_scope: local_cooperating_processes
+```
+
+Global exactly-once requires a vendor idempotency key or compare-and-set send contract.
+
+After a network timeout, reset, or HTTP conflict, `shm` reconciles the same attempt. It never automatically posts again after the pre-network claim. An unresolved outcome remains `unknown`/pending and exits 4.
+
+## Private state and test controls
+
+Production HMAC keys are created/read from macOS Keychain service `superhuman-mail-attestation-v1`.
+
+These environment variables exist for controlled rollout/testing:
+
+- `SHM_STATE_DIR`
+- `SHM_RENDERER_CDP_URL`
+- `SHM_RENDERER_WINDOW_ID`
+- `SHM_RENDERER_ALLOW_VERSIONS`
+- `SHM_ATTESTATION_KEY` (tests only; do not use as a production secret path)
+
+A new Superhuman code version fails closed until its renderer contract and non-sending E2E are reviewed.

--- a/docs/send-safety.md
+++ b/docs/send-safety.md
@@ -87,7 +87,8 @@ The adapter:
 - mirrors the current build's reminder behavior: reminder stays on the persisted, fingerprint-bound draft and is not copied into `toJsonRequest()`;
 - rejects inline signature uploads that cannot be materialized read-only;
 - captures the compose view and a network-disabled rendering of the exact outgoing HTML;
-- enables CDP Fetch interception and target-offline mode before focus/render work, aborting every non-allowlisted non-idempotent request before dispatch and failing the attestation if the app attempted one;
+- requires the exact draft model to already be visible and never focuses or navigates the app;
+- enables CDP Fetch interception and target-offline mode before render work, aborting every non-allowlisted non-idempotent request before dispatch and failing the attestation if the app attempted one;
 - re-reads the server snapshot and history after rendering;
 - signs an expiring canonical artifact with a Keychain-held HMAC key.
 

--- a/docs/send-safety.md
+++ b/docs/send-safety.md
@@ -87,7 +87,7 @@ The adapter:
 - mirrors the current build's reminder behavior: reminder stays on the persisted, fingerprint-bound draft and is not copied into `toJsonRequest()`;
 - rejects inline signature uploads that cannot be materialized read-only;
 - captures the compose view and a network-disabled rendering of the exact outgoing HTML;
-- observes network requests and fails closed on every non-idempotent request except an explicit read-only POST allowlist;
+- enables CDP Fetch interception and target-offline mode before focus/render work, aborting every non-allowlisted non-idempotent request before dispatch and failing the attestation if the app attempted one;
 - re-reads the server snapshot and history after rendering;
 - signs an expiring canonical artifact with a Keychain-held HMAC key.
 
@@ -104,17 +104,18 @@ shm attestation show ID_OR_PATH \
   --draft-id DRAFT
 ```
 
-The inspector verifies canonical ID/HMAC, screenshot hashes, expiry, and optional binding. It exposes counts, booleans (including `editor_normalized_changed`), renderer versions, screenshot hashes/paths, and the overall fingerprint only. Valid-but-expired artifacts return `usable: false`; tamper or binding mismatch fails.
+The inspector verifies canonical ID/HMAC, screenshot hashes, expiry, and optional binding. It exposes counts, booleans (including `editor_normalized_changed`), renderer versions, screenshot hashes/paths, the overall fingerprint, and a content-free `approval_binding`. Valid-but-expired artifacts return `usable: false`; tamper or binding mismatch fails.
 
 ### 4. Grace period and strict execution
 
-An external gate displays the safe attestation summary, records an opaque approval reference, and runs its grace period. It then invokes:
+The external Slack approval broker records the exact `approval_binding`, presents the complete message, authenticates the authorized human decision, and issues a ≤5-minute Ed25519 receipt. Verify it read-only, then let the credential-isolated trusted executor run its grace period and invoke:
 
 ```bash
+shm approval verify RECEIPT.json --attestation ID_OR_PATH
 shm send --confirm THREAD DRAFT \
   --account owner@example.com \
   --attestation ID_OR_PATH \
-  --approval-ref OPAQUE_REFERENCE \
+  --approval-receipt RECEIPT.json \
   --delay 20 \
   --wait 120
 ```
@@ -123,26 +124,23 @@ Immediately before POST, `shm`:
 
 1. reruns authoritative lifecycle/envelope/body preflight;
 2. verifies account, artifact signature, expiry, thread/draft, approved delay, and source history;
-3. creates or resumes one local attempt identity;
-4. runs a second no-write live-Superhuman renderer probe with the reserved ID;
-5. requires the complete exact fingerprint and outgoing payload bytes to equal approval;
-6. atomically claims the only local POST before network I/O;
-7. posts the freshly probed exact payload;
-8. reconciles userdata/provider evidence without minting another identity.
+3. verifies the receipt schema/canonical ID, pinned issuer/key, Ed25519 signature, authorized approver, lifetime, action/provider, and exact attestation binding;
+4. creates or resumes one receipt-bound local attempt identity;
+5. runs a second no-write live-Superhuman renderer probe with the reserved ID;
+6. requires the complete exact fingerprint and outgoing payload bytes to equal approval;
+7. in one `BEGIN IMMEDIATE`, rechecks expiry, consumes the receipt ID, and claims the only local POST;
+8. posts the freshly probed exact payload;
+9. reconciles userdata/provider evidence without minting another identity.
 
 There is no unattested fallback for customer mail.
 
 ## Approval authority boundary
 
-`--approval-ref` is audit correlation only. Core `shm` does not verify that the reference was issued by a human or an independent authority, and its result says:
+Caller-controlled `--approval-ref` is deprecated correlation and never authorizes. Before external verification, results say `approval_authority: external_receipt_required`, `approval_verified: false`, and `unattended_send_eligible: false`. A verified receipt changes authority to `external_ed25519_receipt_v1`; its ID/issuer/key are journaled and its one local consumption is atomic with the POST claim.
 
-```text
-approval_authority: correlation_only
-approval_verified: false
-unattended_send_eligible: false
-```
+Environment variables and user-writable files cannot install receipt trust roots. Roots are release-pinned or loaded from `/Library/Application Support/superhuman-mail/approval-trust-v1.json` only when it is a root-owned regular file not writable by group/others. With no root, confirm fails `APPROVAL_TRUST_UNAVAILABLE`.
 
-Therefore unattended automation must hard-disable `--confirm`. An operator may invoke a send only after the full message has been explicitly approved and through the external 60-second `send-gate`. A future unattended path requires a signed, single-use capability from an issuer whose signing key is unavailable to the worker; same-process CLI arguments, environment variables, or same-UID files are not an approval trust boundary. `shm attestation show` verifies render integrity, not human approval.
+This verifier does not by itself isolate transport credentials. Production must run it and the POST inside one canonical, durable, broker-owned/root-owned or remote trusted executor; the unattended worker must not possess Superhuman write credentials, the issuer private key, a writable verifier/trust root, or a local/raw transport fallback. See [`approval-receipt-issuer-contract.md`](approval-receipt-issuer-contract.md).
 
 ## Result and exit contract
 
@@ -151,7 +149,8 @@ Send/status data includes:
 ```text
 state, post_claimed, accepted, sent, provider_confirmed, outbound_evidence
 attempt_id, attestation_id, superhuman_id, provider_message_id
-approval_authority, approval_verified, unattended_send_eligible
+approval_authority, approval_verified, approval_consumed, approval_receipt_id
+approval_issuer, approval_key_id, unattended_send_eligible, trusted_executor_required
 idempotency_scope, lifecycle
 ```
 
@@ -165,9 +164,9 @@ Follow-up/CRM automation must consume only `provider_confirmed: true` / `state: 
 
 ## Idempotency scope
 
-The SQLite attempt journal lives in one canonical private per-user state directory. A unique `(immutable_provider_user_id, draft_id)` row and `BEGIN IMMEDIATE` claim guarantee one POST for cooperating `shm` processes sharing that journal.
+The SQLite attempt journal must live in the canonical durable state directory of the trusted executor. A unique `(immutable_provider_user_id, draft_id)` row, permanent receipt-consumption identity, and `BEGIN IMMEDIATE` transaction guarantee one receipt consumption/POST claim for cooperating executor processes sharing that journal.
 
-This does **not** serialize another host, another state directory, the native Superhuman UI, or an uncooperative caller. Outputs therefore say:
+This does **not** serialize another executor host/state directory or the native Superhuman UI. Production therefore permits transport credentials in only one canonical executor authority. Outputs continue to state the narrower mechanism scope:
 
 ```text
 idempotency_scope: local_cooperating_processes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "superhuman-mail"
-version = "0.2.1"
+version = "0.3.0"
 description = "Unofficial Superhuman mail API client and agent-friendly CLI"
 requires-python = ">=3.11"
 license = "MIT"
@@ -12,6 +12,9 @@ dependencies = ["cryptography"]
 
 [tool.setuptools.packages.find]
 include = ["superhuman_mail*"]
+
+[tool.setuptools.package-data]
+superhuman_mail = ["renderer_probe.js"]
 
 [project.scripts]
 shm = "superhuman_mail.cli:main"

--- a/superhuman_mail/__init__.py
+++ b/superhuman_mail/__init__.py
@@ -3,4 +3,4 @@
 from .client import Client
 
 __all__ = ["Client"]
-__version__ = "0.2.1"
+__version__ = "0.3.0"

--- a/superhuman_mail/_state.py
+++ b/superhuman_mail/_state.py
@@ -1,0 +1,26 @@
+"""Private local state paths and permissions."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def state_dir() -> Path:
+    raw = os.environ.get("SHM_STATE_DIR")
+    path = Path(raw).expanduser() if raw else Path.home() / "Library" / "Application Support" / "superhuman-mail"
+    path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    try:
+        path.chmod(0o700)
+    except OSError:
+        pass
+    return path
+
+
+def private_file(path: Path) -> Path:
+    """Best-effort enforce 0600 on an existing local state file."""
+    if path.exists():
+        try:
+            path.chmod(0o600)
+        except OSError:
+            pass
+    return path

--- a/superhuman_mail/approval.py
+++ b/superhuman_mail/approval.py
@@ -1,0 +1,346 @@
+"""Externally issued, exact-send approval receipt verification.
+
+This module deliberately contains no receipt-minting path. Production trust roots
+are either compiled into the package or installed in a root-owned, non-writable
+system trust store. The unattended worker receives public verification material
+only; the issuer's Ed25519 private key must remain in the external approval broker.
+"""
+from __future__ import annotations
+
+import base64
+import hmac
+import json
+import os
+import stat
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from cryptography.exceptions import InvalidSignature  # pyright: ignore[reportMissingImports]
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (  # pyright: ignore[reportMissingImports]
+    Ed25519PublicKey,
+)
+
+from ._state import private_file, state_dir
+from .attestation import canonical_bytes, sha256
+
+SCHEMA = "shm-approval-receipt/v1"
+TRUST_SCHEMA = "shm-approval-trust/v1"
+AUTHORITY = "external_ed25519_receipt_v1"
+ACTION = "superhuman.send"
+PROVIDER = "superhuman"
+MAX_TTL = timedelta(minutes=5)
+MAX_CLOCK_SKEW = timedelta(seconds=30)
+TRUST_STORE_PATH = Path("/Library/Application Support/superhuman-mail/approval-trust-v1.json")
+
+# Release-pinned roots may be added here after the external issuer has generated
+# its keypair. Never add a private key or a caller-controlled environment path.
+BUILTIN_TRUST_ROOTS: dict[str, dict[str, Any]] = {}
+
+
+class ApprovalError(RuntimeError):
+    """A receipt is absent, forged, stale, replayed, or bound elsewhere."""
+
+    def __init__(self, code: str, hint: str) -> None:
+        super().__init__(hint)
+        self.code = code
+        self.hint = hint
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_iso(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _hash_text(value: Any) -> str:
+    return sha256(str(value or "").encode())
+
+
+def _b64decode(value: str) -> bytes:
+    raw = value.encode()
+    raw += b"=" * (-len(raw) % 4)
+    try:
+        return base64.urlsafe_b64decode(raw)
+    except Exception as exc:
+        raise ApprovalError("APPROVAL_RECEIPT_INVALID", "Approval receipt contains invalid base64") from exc
+
+
+def binding_for_attestation(record: dict[str, Any]) -> dict[str, Any]:
+    """Build the content-free exact-send binding an external issuer must sign."""
+    payload = record.get("outgoing_payload") or {}
+    envelope = {
+        "from": payload.get("from"),
+        "to": payload.get("to") or [],
+        "cc": payload.get("cc") or [],
+        "bcc": payload.get("bcc") or [],
+    }
+    renderer = record.get("renderer") or {}
+    screenshot_hashes = [str(item.get("sha256") or "") for item in (record.get("screenshots") or [])]
+    return {
+        "action": ACTION,
+        "provider": PROVIDER,
+        "account_provider_user_id_sha256": _hash_text((record.get("account") or {}).get("provider_user_id")),
+        "account_email_sha256": _hash_text(str((record.get("account") or {}).get("email") or "").lower()),
+        "thread_id_sha256": _hash_text(record.get("thread_id")),
+        "draft_id_sha256": _hash_text(record.get("draft_id")),
+        "attestation_id": str(record.get("attestation_id") or ""),
+        "outgoing_fingerprint": str((record.get("fingerprint") or {}).get("exact") or ""),
+        "outgoing_payload_sha256": sha256(canonical_bytes(payload)),
+        "recipient_envelope_sha256": sha256(canonical_bytes(envelope)),
+        "renderer_build_sha256": sha256(canonical_bytes({
+            "adapter_version": renderer.get("adapter_version"),
+            "app_version": renderer.get("app_version"),
+            "web_version": renderer.get("web_version"),
+        })),
+        "screenshot_set_sha256": sha256(canonical_bytes(screenshot_hashes)),
+        "send_identity_sha256": _hash_text(record.get("superhuman_id")),
+        "delay_seconds": int(record.get("delay_seconds", -1)),
+        "scheduled_for_sha256": _hash_text(payload.get("scheduled_for")),
+    }
+
+
+def _receipt_content(record: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in record.items() if key not in {"receipt_id", "signature"}}
+
+
+def _signed_content(record: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in record.items() if key != "signature"}
+
+
+def _validate_structure(record: dict[str, Any]) -> None:
+    expected_fields = {
+        "schema", "receipt_id", "issuer", "key_id", "issued_at", "expires_at",
+        "nonce", "approver", "action", "provider", "binding", "signature",
+    }
+    if set(record) != expected_fields:
+        raise ApprovalError("APPROVAL_RECEIPT_INVALID", "Approval receipt fields do not match schema v1")
+    if record.get("schema") != SCHEMA:
+        raise ApprovalError("APPROVAL_RECEIPT_INVALID", "Unsupported approval receipt schema")
+    for key in ("receipt_id", "issuer", "key_id", "issued_at", "expires_at", "nonce", "signature"):
+        if not isinstance(record.get(key), str) or not record[key]:
+            raise ApprovalError("APPROVAL_RECEIPT_INVALID", f"Approval receipt is missing {key}")
+    if not record["receipt_id"].startswith("sha256:") or len(record["receipt_id"]) != 71:
+        raise ApprovalError("APPROVAL_RECEIPT_INVALID", "Approval receipt ID is malformed")
+    if not 16 <= len(record["nonce"]) <= 256:
+        raise ApprovalError("APPROVAL_RECEIPT_INVALID", "Approval receipt nonce is malformed")
+    if record.get("action") != ACTION or record.get("provider") != PROVIDER:
+        raise ApprovalError("APPROVAL_ACTION_MISMATCH", "Approval receipt is for a different action or provider")
+    if not isinstance(record.get("binding"), dict):
+        raise ApprovalError("APPROVAL_RECEIPT_INVALID", "Approval receipt binding is malformed")
+    approver = record.get("approver")
+    if not isinstance(approver, dict) or set(approver) != {"principal", "approval_event_id"} or not all(
+        isinstance(approver.get(key), str) and approver.get(key)
+        for key in ("principal", "approval_event_id")
+    ):
+        raise ApprovalError("APPROVAL_RECEIPT_INVALID", "Approval receipt approver evidence is malformed")
+
+
+def _read_system_trust_store() -> dict[str, dict[str, Any]]:
+    if not TRUST_STORE_PATH.exists():
+        return {}
+    try:
+        current = TRUST_STORE_PATH.parent
+        while current != current.parent:
+            metadata = current.lstat()
+            if not stat.S_ISDIR(metadata.st_mode) or metadata.st_uid != 0 or metadata.st_mode & 0o022:
+                raise ApprovalError(
+                    "APPROVAL_TRUST_UNSAFE",
+                    "Approval trust-store directory chain must be root-owned and non-writable",
+                )
+            current = current.parent
+        descriptor = os.open(TRUST_STORE_PATH, os.O_RDONLY | os.O_NOFOLLOW)
+        try:
+            metadata = os.fstat(descriptor)
+            if not stat.S_ISREG(metadata.st_mode) or metadata.st_uid != 0 or metadata.st_mode & 0o022:
+                raise ApprovalError(
+                    "APPROVAL_TRUST_UNSAFE",
+                    "Approval trust store must be root-owned and not writable by group/others",
+                )
+            with os.fdopen(descriptor, encoding="utf-8") as handle:
+                descriptor = -1
+                value = json.load(handle)
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+    except ApprovalError:
+        raise
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ApprovalError("APPROVAL_TRUST_UNAVAILABLE", "Cannot read the system approval trust store") from exc
+    if not isinstance(value, dict) or value.get("schema") != TRUST_SCHEMA or not isinstance(value.get("issuers"), dict):
+        raise ApprovalError("APPROVAL_TRUST_UNAVAILABLE", "System approval trust store is malformed")
+    return value["issuers"]
+
+
+def trusted_issuers() -> dict[str, dict[str, Any]]:
+    roots = {key: dict(value) for key, value in BUILTIN_TRUST_ROOTS.items()}
+    for issuer, configuration in _read_system_trust_store().items():
+        if issuer in roots and roots[issuer] != configuration:
+            raise ApprovalError("APPROVAL_TRUST_CONFLICT", f"Conflicting approval trust root for {issuer}")
+        if not isinstance(configuration, dict):
+            raise ApprovalError("APPROVAL_TRUST_UNAVAILABLE", f"Malformed approval trust root for {issuer}")
+        roots[issuer] = dict(configuration)
+    if not roots:
+        raise ApprovalError(
+            "APPROVAL_TRUST_UNAVAILABLE",
+            "No externally isolated approval issuer is pinned; strict send is disabled",
+        )
+    return roots
+
+
+def load(reference: str | Path) -> dict[str, Any]:
+    try:
+        path = Path(reference).expanduser()
+        if not path.is_file():
+            raise ApprovalError("APPROVAL_RECEIPT_NOT_FOUND", "Approval receipt file was not found")
+        if path.stat().st_size > 64 * 1024:
+            raise ApprovalError("APPROVAL_RECEIPT_INVALID", "Approval receipt exceeds 64 KiB")
+        record = json.loads(path.read_text())
+    except ApprovalError:
+        raise
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ApprovalError("APPROVAL_RECEIPT_INVALID", "Approval receipt is not valid JSON") from exc
+    if not isinstance(record, dict):
+        raise ApprovalError("APPROVAL_RECEIPT_INVALID", "Approval receipt must be a JSON object")
+    return record
+
+
+def verify(
+    record: dict[str, Any],
+    *,
+    attestation: dict[str, Any],
+    roots: dict[str, dict[str, Any]] | None = None,
+    now: datetime | None = None,
+    require_unexpired: bool = True,
+) -> dict[str, Any]:
+    """Verify external authority, lifetime, exact binding, and canonical identity."""
+    _validate_structure(record)
+    expected_receipt_id = sha256(canonical_bytes(_receipt_content(record)))
+    if not hmac.compare_digest(record["receipt_id"], expected_receipt_id):
+        raise ApprovalError("APPROVAL_RECEIPT_TAMPERED", "Approval receipt ID does not match canonical content")
+
+    roots = roots if roots is not None else trusted_issuers()
+    issuer = roots.get(record["issuer"])
+    if not isinstance(issuer, dict) or issuer.get("key_id") != record["key_id"]:
+        raise ApprovalError("APPROVAL_ISSUER_UNTRUSTED", "Approval receipt issuer/key is not pinned")
+    allowed_approvers = issuer.get("allowed_approvers") or []
+    principal = record["approver"]["principal"]
+    if principal not in allowed_approvers:
+        raise ApprovalError("APPROVER_UNAUTHORIZED", "Approval receipt approver is not authorized")
+
+    public_key_bytes = _b64decode(str(issuer.get("public_key") or ""))
+    if len(public_key_bytes) != 32:
+        raise ApprovalError("APPROVAL_TRUST_UNAVAILABLE", "Pinned Ed25519 public key is malformed")
+    signature = str(record["signature"])
+    if not signature.startswith("ed25519:"):
+        raise ApprovalError("APPROVAL_RECEIPT_INVALID", "Approval receipt signature algorithm is unsupported")
+    signature_bytes = _b64decode(signature.split(":", 1)[1])
+    if len(signature_bytes) != 64:
+        raise ApprovalError("APPROVAL_RECEIPT_INVALID", "Ed25519 approval signature is malformed")
+    try:
+        Ed25519PublicKey.from_public_bytes(public_key_bytes).verify(
+            signature_bytes,
+            canonical_bytes(_signed_content(record)),
+        )
+    except InvalidSignature as exc:
+        raise ApprovalError("APPROVAL_RECEIPT_FORGED", "Approval receipt signature is invalid") from exc
+
+    try:
+        issued_at = _parse_iso(record["issued_at"])
+        expires_at = _parse_iso(record["expires_at"])
+    except (TypeError, ValueError) as exc:
+        raise ApprovalError("APPROVAL_RECEIPT_INVALID", "Approval receipt lifetime is malformed") from exc
+    current = now or _now()
+    if issued_at > current + MAX_CLOCK_SKEW:
+        raise ApprovalError("APPROVAL_RECEIPT_NOT_YET_VALID", "Approval receipt issue time is in the future")
+    expired = expires_at <= current
+    if require_unexpired and expired:
+        raise ApprovalError("APPROVAL_RECEIPT_EXPIRED", "Approval receipt has expired")
+    if expires_at <= issued_at or expires_at - issued_at > MAX_TTL:
+        raise ApprovalError("APPROVAL_RECEIPT_INVALID", "Approval receipt lifetime exceeds the five-minute maximum")
+
+    expected_binding = binding_for_attestation(attestation)
+    if not hmac.compare_digest(canonical_bytes(record["binding"]), canonical_bytes(expected_binding)):
+        raise ApprovalError("APPROVAL_BINDING_MISMATCH", "Approval receipt does not bind this exact send")
+
+    return {
+        "authority": AUTHORITY,
+        "verified": True,
+        "receipt_id": record["receipt_id"],
+        "receipt_digest": sha256(canonical_bytes(record)),
+        "issuer": record["issuer"],
+        "key_id": record["key_id"],
+        "approver": principal,
+        "approval_event_id": record["approver"]["approval_event_id"],
+        "issued_at": record["issued_at"],
+        "expires_at": record["expires_at"],
+        "expired": expired,
+        "binding": expected_binding,
+    }
+
+
+def load_and_verify(reference: str | Path, *, attestation: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    receipt = load(reference)
+    verified = verify(receipt, attestation=attestation)
+    archive(receipt)
+    return receipt, verified
+
+
+def show_safe(
+    reference: str | Path,
+    *,
+    attestation_reference: str | Path,
+    journal: Any | None = None,
+) -> dict[str, Any]:
+    """Return content-free typed verification and replay-consumption state."""
+    from . import attestation as _attestation
+    from .attempts import AttemptJournal
+
+    attestation = _attestation.load(attestation_reference)
+    _attestation.verify(attestation)
+    receipt = load(reference)
+    verified = verify(receipt, attestation=attestation, require_unexpired=False)
+    active_journal = journal if journal is not None else AttemptJournal()
+    consumption = active_journal.get_receipt_consumption(verified["receipt_id"])
+    return {
+        "authority": AUTHORITY,
+        "verified": True,
+        "usable": not verified["expired"] and consumption is None,
+        "unattended_send_eligible": False,
+        "trusted_executor_required": True,
+        "expired": verified["expired"],
+        "consumed": consumption is not None,
+        "receipt_id": verified["receipt_id"],
+        "receipt_digest": verified["receipt_digest"],
+        "issuer": verified["issuer"],
+        "key_id": verified["key_id"],
+        "approver": verified["approver"],
+        "approval_event_id_sha256": _hash_text(verified["approval_event_id"]),
+        "issued_at": verified["issued_at"],
+        "expires_at": verified["expires_at"],
+        "attestation_id": attestation["attestation_id"],
+        "outgoing_fingerprint": (attestation.get("fingerprint") or {}).get("exact"),
+        "binding": verified["binding"],
+    }
+
+
+def archive(record: dict[str, Any]) -> Path:
+    directory = state_dir() / "approval-receipts"
+    directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+    try:
+        directory.chmod(0o700)
+    except OSError:
+        pass
+    receipt_id = str(record["receipt_id"]).removeprefix("sha256:")
+    path = directory / f"{receipt_id}.json"
+    encoded = canonical_bytes(record) + b"\n"
+    if path.exists() and path.read_bytes() != encoded:
+        raise ApprovalError("APPROVAL_RECEIPT_TAMPERED", "Archived receipt ID already has different content")
+    path.write_bytes(encoded)
+    private_file(path)
+    return path

--- a/superhuman_mail/approval.py
+++ b/superhuman_mail/approval.py
@@ -66,7 +66,7 @@ def _b64decode(value: str) -> bytes:
     raw = value.encode()
     raw += b"=" * (-len(raw) % 4)
     try:
-        return base64.urlsafe_b64decode(raw)
+        return base64.b64decode(raw, altchars=b"-_", validate=True)
     except Exception as exc:
         raise ApprovalError("APPROVAL_RECEIPT_INVALID", "Approval receipt contains invalid base64") from exc
 
@@ -229,6 +229,13 @@ def verify(
     if not isinstance(issuer, dict) or issuer.get("key_id") != record["key_id"]:
         raise ApprovalError("APPROVAL_ISSUER_UNTRUSTED", "Approval receipt issuer/key is not pinned")
     allowed_approvers = issuer.get("allowed_approvers") or []
+    if (
+        not isinstance(issuer.get("public_key"), str)
+        or not isinstance(allowed_approvers, list)
+        or not allowed_approvers
+        or any(not isinstance(item, str) or not item for item in allowed_approvers)
+    ):
+        raise ApprovalError("APPROVAL_TRUST_UNAVAILABLE", "Pinned approval issuer configuration is malformed")
     principal = record["approver"]["principal"]
     if principal not in allowed_approvers:
         raise ApprovalError("APPROVER_UNAUTHORIZED", "Approval receipt approver is not authorized")

--- a/superhuman_mail/attempts.py
+++ b/superhuman_mail/attempts.py
@@ -122,7 +122,7 @@ class AttemptJournal:
                 );
                 """
             )
-            columns = {row[1] for row in conn.execute("PRAGMA table_info(attempts)")}
+            conn.execute("BEGIN IMMEDIATE")
             migrations = {
                 "approval_receipt_id": "TEXT",
                 "approval_receipt_digest": "TEXT",
@@ -133,8 +133,14 @@ class AttemptJournal:
                 "approval_expires_at": "TEXT",
             }
             for column, column_type in migrations.items():
+                columns = {row[1] for row in conn.execute("PRAGMA table_info(attempts)")}
                 if column not in columns:
                     conn.execute(f"ALTER TABLE attempts ADD COLUMN {column} {column_type}")
+            conn.execute("COMMIT")
+        except Exception:
+            if conn.in_transaction:
+                conn.execute("ROLLBACK")
+            raise
         finally:
             conn.close()
             private_file(self.path)

--- a/superhuman_mail/attempts.py
+++ b/superhuman_mail/attempts.py
@@ -21,10 +21,23 @@ TERMINAL_ATTEMPT_STATES = {
     "send_failed",
     "send_aborted",
 }
+PURGEABLE_ATTEMPT_STATES = {
+    "send_failed",
+    "send_aborted",
+}
 
 
 class AttemptConflict(RuntimeError):
     """An existing attempt cannot be reused for a different approval/payload."""
+
+
+class ReceiptClaimError(RuntimeError):
+    """A verified approval receipt cannot be atomically consumed."""
+
+    def __init__(self, code: str, hint: str) -> None:
+        super().__init__(hint)
+        self.code = code
+        self.hint = hint
 
 
 def _now() -> str:
@@ -78,6 +91,13 @@ class AttemptJournal:
                     draft_id TEXT NOT NULL,
                     attestation_id TEXT NOT NULL,
                     approval_ref_hash TEXT NOT NULL,
+                    approval_receipt_id TEXT,
+                    approval_receipt_digest TEXT,
+                    approval_issuer TEXT,
+                    approval_key_id TEXT,
+                    approval_approver TEXT,
+                    approval_issued_at TEXT,
+                    approval_expires_at TEXT,
                     superhuman_id TEXT NOT NULL,
                     outgoing_fingerprint TEXT NOT NULL,
                     created_at TEXT NOT NULL,
@@ -93,8 +113,28 @@ class AttemptJournal:
                     UNIQUE(account_id, draft_id)
                 );
                 CREATE INDEX IF NOT EXISTS attempts_updated_at ON attempts(updated_at);
+                CREATE TABLE IF NOT EXISTS approval_receipt_consumptions (
+                    receipt_id TEXT PRIMARY KEY,
+                    receipt_digest TEXT NOT NULL,
+                    attempt_id TEXT NOT NULL UNIQUE,
+                    consumed_at TEXT NOT NULL,
+                    FOREIGN KEY(attempt_id) REFERENCES attempts(attempt_id)
+                );
                 """
             )
+            columns = {row[1] for row in conn.execute("PRAGMA table_info(attempts)")}
+            migrations = {
+                "approval_receipt_id": "TEXT",
+                "approval_receipt_digest": "TEXT",
+                "approval_issuer": "TEXT",
+                "approval_key_id": "TEXT",
+                "approval_approver": "TEXT",
+                "approval_issued_at": "TEXT",
+                "approval_expires_at": "TEXT",
+            }
+            for column, column_type in migrations.items():
+                if column not in columns:
+                    conn.execute(f"ALTER TABLE attempts ADD COLUMN {column} {column_type}")
         finally:
             conn.close()
             private_file(self.path)
@@ -122,6 +162,18 @@ class AttemptJournal:
         finally:
             conn.close()
 
+    def get_receipt_consumption(self, receipt_id: str) -> dict[str, Any] | None:
+        conn = self._connect()
+        try:
+            return self._row(
+                conn.execute(
+                    "SELECT * FROM approval_receipt_consumptions WHERE receipt_id = ?",
+                    (receipt_id,),
+                ).fetchone()
+            )
+        finally:
+            conn.close()
+
     def create_or_get(
         self,
         *,
@@ -130,13 +182,19 @@ class AttemptJournal:
         thread_id: str,
         draft_id: str,
         attestation_id: str,
-        approval_ref: str,
+        approval_receipt_id: str,
+        approval_receipt_digest: str,
+        approval_issuer: str,
+        approval_key_id: str,
+        approval_approver: str,
+        approval_issued_at: str,
+        approval_expires_at: str,
         superhuman_id: str,
         outgoing_fingerprint: str,
     ) -> tuple[dict[str, Any], bool]:
         """Atomically create one attempt or return its exact compatible row."""
         now = _now()
-        approval_hash = _hash_ref(approval_ref)
+        approval_hash = _hash_ref(approval_receipt_id)
         attempt_id = str(uuid.uuid4())
         conn = self._connect()
         try:
@@ -151,6 +209,13 @@ class AttemptJournal:
                     "thread_id": thread_id,
                     "attestation_id": attestation_id,
                     "approval_ref_hash": approval_hash,
+                    "approval_receipt_id": approval_receipt_id,
+                    "approval_receipt_digest": approval_receipt_digest,
+                    "approval_issuer": approval_issuer,
+                    "approval_key_id": approval_key_id,
+                    "approval_approver": approval_approver,
+                    "approval_issued_at": approval_issued_at,
+                    "approval_expires_at": approval_expires_at,
                     "superhuman_id": superhuman_id,
                     "outgoing_fingerprint": outgoing_fingerprint,
                 }
@@ -165,6 +230,9 @@ class AttemptJournal:
                             UPDATE attempts SET
                                 attempt_id = ?, account_hash = ?, thread_id = ?,
                                 attestation_id = ?, approval_ref_hash = ?,
+                                approval_receipt_id = ?, approval_receipt_digest = ?,
+                                approval_issuer = ?, approval_key_id = ?,
+                                approval_approver = ?, approval_issued_at = ?, approval_expires_at = ?,
                                 superhuman_id = ?, outgoing_fingerprint = ?,
                                 created_at = ?, updated_at = ?, state = 'prepared',
                                 response_class = NULL, last_error = NULL,
@@ -178,6 +246,13 @@ class AttemptJournal:
                                 thread_id,
                                 attestation_id,
                                 approval_hash,
+                                approval_receipt_id,
+                                approval_receipt_digest,
+                                approval_issuer,
+                                approval_key_id,
+                                approval_approver,
+                                approval_issued_at,
+                                approval_expires_at,
                                 superhuman_id,
                                 outgoing_fingerprint,
                                 now,
@@ -202,9 +277,11 @@ class AttemptJournal:
                 """
                 INSERT INTO attempts (
                     attempt_id, account_id, account_hash, thread_id, draft_id,
-                    attestation_id, approval_ref_hash, superhuman_id,
-                    outgoing_fingerprint, created_at, updated_at, state
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'prepared')
+                    attestation_id, approval_ref_hash, approval_receipt_id,
+                    approval_receipt_digest, approval_issuer, approval_key_id,
+                    approval_approver, approval_issued_at, approval_expires_at,
+                    superhuman_id, outgoing_fingerprint, created_at, updated_at, state
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'prepared')
                 """,
                 (
                     attempt_id,
@@ -214,6 +291,13 @@ class AttemptJournal:
                     draft_id,
                     attestation_id,
                     approval_hash,
+                    approval_receipt_id,
+                    approval_receipt_digest,
+                    approval_issuer,
+                    approval_key_id,
+                    approval_approver,
+                    approval_issued_at,
+                    approval_expires_at,
                     superhuman_id,
                     outgoing_fingerprint,
                     now,
@@ -231,8 +315,15 @@ class AttemptJournal:
         finally:
             conn.close()
 
-    def claim_post(self, attempt_id: str) -> tuple[dict[str, Any], bool]:
-        """Claim the only automatic POST before any network bytes are attempted."""
+    def claim_post(
+        self,
+        attempt_id: str,
+        *,
+        approval_receipt_id: str,
+        approval_receipt_digest: str,
+        approval_expires_at: str,
+    ) -> tuple[dict[str, Any], bool]:
+        """Atomically consume one approval receipt and claim the only POST."""
         conn = self._connect()
         try:
             conn.execute("BEGIN IMMEDIATE")
@@ -244,7 +335,43 @@ class AttemptJournal:
             if current["state"] != "prepared" or int(current["post_count"]) != 0:
                 conn.execute("COMMIT")
                 return current, False
-            now = _now()
+            if (
+                current.get("approval_receipt_id") != approval_receipt_id
+                or current.get("approval_receipt_digest") != approval_receipt_digest
+                or current.get("approval_expires_at") != approval_expires_at
+            ):
+                conn.execute("ROLLBACK")
+                raise ReceiptClaimError(
+                    "APPROVAL_BINDING_MISMATCH",
+                    "Attempt and approval receipt bindings differ",
+                )
+            now_dt = datetime.now(timezone.utc)
+            try:
+                expires_dt = datetime.fromisoformat(approval_expires_at.replace("Z", "+00:00"))
+                if expires_dt.tzinfo is None:
+                    expires_dt = expires_dt.replace(tzinfo=timezone.utc)
+            except ValueError as exc:
+                conn.execute("ROLLBACK")
+                raise ReceiptClaimError("APPROVAL_RECEIPT_INVALID", "Receipt expiry is malformed") from exc
+            if expires_dt.astimezone(timezone.utc) <= now_dt:
+                conn.execute("ROLLBACK")
+                raise ReceiptClaimError("APPROVAL_RECEIPT_EXPIRED", "Receipt expired before POST claim")
+            consumed = conn.execute(
+                "SELECT * FROM approval_receipt_consumptions WHERE receipt_id = ?",
+                (approval_receipt_id,),
+            ).fetchone()
+            if consumed is not None:
+                conn.execute("ROLLBACK")
+                raise ReceiptClaimError("APPROVAL_RECEIPT_REPLAYED", "Approval receipt was already consumed")
+            now = now_dt.isoformat(timespec="microseconds").replace("+00:00", "Z")
+            conn.execute(
+                """
+                INSERT INTO approval_receipt_consumptions (
+                    receipt_id, receipt_digest, attempt_id, consumed_at
+                ) VALUES (?, ?, ?, ?)
+                """,
+                (approval_receipt_id, approval_receipt_digest, attempt_id, now),
+            )
             conn.execute(
                 "UPDATE attempts SET state = 'posting', post_count = 1, updated_at = ? WHERE attempt_id = ?",
                 (now, attempt_id),
@@ -299,12 +426,12 @@ class AttemptJournal:
         cutoff = (datetime.now(timezone.utc) - timedelta(days=retention_days)).isoformat(
             timespec="microseconds"
         ).replace("+00:00", "Z")
-        placeholders = ",".join("?" for _ in TERMINAL_ATTEMPT_STATES)
+        placeholders = ",".join("?" for _ in PURGEABLE_ATTEMPT_STATES)
         conn = self._connect()
         try:
             changed = conn.execute(
                 f"DELETE FROM attempts WHERE state IN ({placeholders}) AND updated_at < ?",
-                (*sorted(TERMINAL_ATTEMPT_STATES), cutoff),
+                (*sorted(PURGEABLE_ATTEMPT_STATES), cutoff),
             )
             return int(changed.rowcount)
         finally:

--- a/superhuman_mail/attempts.py
+++ b/superhuman_mail/attempts.py
@@ -1,0 +1,311 @@
+"""Local idempotent send-attempt journal.
+
+The guarantee is deliberately scoped to cooperating ``shm`` processes sharing
+one canonical state directory.  It does not claim cross-host or native-UI
+serialization without a vendor idempotency/CAS contract.
+"""
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from ._state import private_file, state_dir
+
+IDEMPOTENCY_SCOPE = "local_cooperating_processes"
+TERMINAL_ATTEMPT_STATES = {
+    "sent_provider_confirmed",
+    "send_failed",
+    "send_aborted",
+}
+
+
+class AttemptConflict(RuntimeError):
+    """An existing attempt cannot be reused for a different approval/payload."""
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def _hash_ref(value: str) -> str:
+    return "sha256:" + hashlib.sha256(value.encode()).hexdigest()
+
+
+class AttemptJournal:
+    """SQLite journal with an atomic one-POST claim per account/draft."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        self.path = path or (state_dir() / "attempts.sqlite3")
+        self.path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        try:
+            self.path.parent.chmod(0o700)
+        except OSError:
+            pass
+        self._initialize()
+        self.purge_terminal(retention_days=30)
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.path, timeout=30, isolation_level=None)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA busy_timeout=30000")
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+        except sqlite3.OperationalError as exc:
+            # Concurrent first-open may briefly hold the journal-mode lock; the
+            # winning connection establishes WAL before either can claim work.
+            if "locked" not in str(exc).lower():
+                raise
+        conn.execute("PRAGMA synchronous=FULL")
+        private_file(self.path)
+        private_file(Path(str(self.path) + "-wal"))
+        private_file(Path(str(self.path) + "-shm"))
+        return conn
+
+    def _initialize(self) -> None:
+        conn = self._connect()
+        try:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS attempts (
+                    attempt_id TEXT PRIMARY KEY,
+                    account_id TEXT NOT NULL,
+                    account_hash TEXT NOT NULL,
+                    thread_id TEXT NOT NULL,
+                    draft_id TEXT NOT NULL,
+                    attestation_id TEXT NOT NULL,
+                    approval_ref_hash TEXT NOT NULL,
+                    superhuman_id TEXT NOT NULL,
+                    outgoing_fingerprint TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    state TEXT NOT NULL,
+                    post_count INTEGER NOT NULL DEFAULT 0,
+                    response_class TEXT,
+                    last_error TEXT,
+                    last_reconciled_at TEXT,
+                    provider_message_id TEXT,
+                    backend_sent_at TEXT,
+                    provider_sent_at TEXT,
+                    UNIQUE(account_id, draft_id)
+                );
+                CREATE INDEX IF NOT EXISTS attempts_updated_at ON attempts(updated_at);
+                """
+            )
+        finally:
+            conn.close()
+            private_file(self.path)
+
+    @staticmethod
+    def _row(row: sqlite3.Row | None) -> dict[str, Any] | None:
+        return dict(row) if row is not None else None
+
+    def get(self, account_id: str, draft_id: str) -> dict[str, Any] | None:
+        conn = self._connect()
+        try:
+            return self._row(
+                conn.execute(
+                    "SELECT * FROM attempts WHERE account_id = ? AND draft_id = ?",
+                    (account_id, draft_id),
+                ).fetchone()
+            )
+        finally:
+            conn.close()
+
+    def get_by_id(self, attempt_id: str) -> dict[str, Any] | None:
+        conn = self._connect()
+        try:
+            return self._row(conn.execute("SELECT * FROM attempts WHERE attempt_id = ?", (attempt_id,)).fetchone())
+        finally:
+            conn.close()
+
+    def create_or_get(
+        self,
+        *,
+        account_id: str,
+        account_hash: str,
+        thread_id: str,
+        draft_id: str,
+        attestation_id: str,
+        approval_ref: str,
+        superhuman_id: str,
+        outgoing_fingerprint: str,
+    ) -> tuple[dict[str, Any], bool]:
+        """Atomically create one attempt or return its exact compatible row."""
+        now = _now()
+        approval_hash = _hash_ref(approval_ref)
+        attempt_id = str(uuid.uuid4())
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            existing = conn.execute(
+                "SELECT * FROM attempts WHERE account_id = ? AND draft_id = ?",
+                (account_id, draft_id),
+            ).fetchone()
+            if existing is not None:
+                row = dict(existing)
+                expected = {
+                    "thread_id": thread_id,
+                    "attestation_id": attestation_id,
+                    "approval_ref_hash": approval_hash,
+                    "superhuman_id": superhuman_id,
+                    "outgoing_fingerprint": outgoing_fingerprint,
+                }
+                mismatched = [key for key, value in expected.items() if row.get(key) != value]
+                if mismatched:
+                    if row["state"] == "prepared" and int(row["post_count"]) == 0:
+                        # No process has claimed network I/O. Atomically rotate
+                        # the primary attempt ID so a stale concurrent holder
+                        # cannot claim this replacement with its old payload.
+                        conn.execute(
+                            """
+                            UPDATE attempts SET
+                                attempt_id = ?, account_hash = ?, thread_id = ?,
+                                attestation_id = ?, approval_ref_hash = ?,
+                                superhuman_id = ?, outgoing_fingerprint = ?,
+                                created_at = ?, updated_at = ?, state = 'prepared',
+                                response_class = NULL, last_error = NULL,
+                                last_reconciled_at = NULL, provider_message_id = NULL,
+                                backend_sent_at = NULL, provider_sent_at = NULL
+                            WHERE attempt_id = ? AND post_count = 0 AND state = 'prepared'
+                            """,
+                            (
+                                attempt_id,
+                                account_hash,
+                                thread_id,
+                                attestation_id,
+                                approval_hash,
+                                superhuman_id,
+                                outgoing_fingerprint,
+                                now,
+                                now,
+                                row["attempt_id"],
+                            ),
+                        )
+                        replacement = conn.execute(
+                            "SELECT * FROM attempts WHERE attempt_id = ?", (attempt_id,)
+                        ).fetchone()
+                        conn.execute("COMMIT")
+                        assert replacement is not None
+                        return dict(replacement), True
+                    conn.execute("ROLLBACK")
+                    raise AttemptConflict(
+                        "Existing attempt differs in " + ", ".join(mismatched) + "; reconcile it instead of creating a new identity"
+                    )
+                conn.execute("COMMIT")
+                return row, False
+
+            conn.execute(
+                """
+                INSERT INTO attempts (
+                    attempt_id, account_id, account_hash, thread_id, draft_id,
+                    attestation_id, approval_ref_hash, superhuman_id,
+                    outgoing_fingerprint, created_at, updated_at, state
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'prepared')
+                """,
+                (
+                    attempt_id,
+                    account_id,
+                    account_hash,
+                    thread_id,
+                    draft_id,
+                    attestation_id,
+                    approval_hash,
+                    superhuman_id,
+                    outgoing_fingerprint,
+                    now,
+                    now,
+                ),
+            )
+            row = conn.execute("SELECT * FROM attempts WHERE attempt_id = ?", (attempt_id,)).fetchone()
+            conn.execute("COMMIT")
+            assert row is not None
+            return dict(row), True
+        except Exception:
+            if conn.in_transaction:
+                conn.execute("ROLLBACK")
+            raise
+        finally:
+            conn.close()
+
+    def claim_post(self, attempt_id: str) -> tuple[dict[str, Any], bool]:
+        """Claim the only automatic POST before any network bytes are attempted."""
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute("SELECT * FROM attempts WHERE attempt_id = ?", (attempt_id,)).fetchone()
+            if row is None:
+                conn.execute("ROLLBACK")
+                raise KeyError(attempt_id)
+            current = dict(row)
+            if current["state"] != "prepared" or int(current["post_count"]) != 0:
+                conn.execute("COMMIT")
+                return current, False
+            now = _now()
+            conn.execute(
+                "UPDATE attempts SET state = 'posting', post_count = 1, updated_at = ? WHERE attempt_id = ?",
+                (now, attempt_id),
+            )
+            claimed = conn.execute("SELECT * FROM attempts WHERE attempt_id = ?", (attempt_id,)).fetchone()
+            conn.execute("COMMIT")
+            assert claimed is not None
+            return dict(claimed), True
+        except Exception:
+            if conn.in_transaction:
+                conn.execute("ROLLBACK")
+            raise
+        finally:
+            conn.close()
+
+    def update(self, attempt_id: str, *, state: str | None = None, **fields: Any) -> dict[str, Any]:
+        allowed = {
+            "response_class",
+            "last_error",
+            "last_reconciled_at",
+            "provider_message_id",
+            "backend_sent_at",
+            "provider_sent_at",
+        }
+        unknown = set(fields) - allowed
+        if unknown:
+            raise ValueError(f"Unknown attempt fields: {', '.join(sorted(unknown))}")
+        updates: dict[str, Any] = {**fields, "updated_at": _now()}
+        if state is not None:
+            updates["state"] = state
+        assignments = ", ".join(f"{key} = ?" for key in updates)
+        values = list(updates.values()) + [attempt_id]
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            changed = conn.execute(f"UPDATE attempts SET {assignments} WHERE attempt_id = ?", values)
+            if changed.rowcount != 1:
+                conn.execute("ROLLBACK")
+                raise KeyError(attempt_id)
+            row = conn.execute("SELECT * FROM attempts WHERE attempt_id = ?", (attempt_id,)).fetchone()
+            conn.execute("COMMIT")
+            assert row is not None
+            return dict(row)
+        except Exception:
+            if conn.in_transaction:
+                conn.execute("ROLLBACK")
+            raise
+        finally:
+            conn.close()
+
+    def purge_terminal(self, *, retention_days: int = 30) -> int:
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=retention_days)).isoformat(
+            timespec="microseconds"
+        ).replace("+00:00", "Z")
+        placeholders = ",".join("?" for _ in TERMINAL_ATTEMPT_STATES)
+        conn = self._connect()
+        try:
+            changed = conn.execute(
+                f"DELETE FROM attempts WHERE state IN ({placeholders}) AND updated_at < ?",
+                (*sorted(TERMINAL_ATTEMPT_STATES), cutoff),
+            )
+            return int(changed.rowcount)
+        finally:
+            conn.close()

--- a/superhuman_mail/attestation.py
+++ b/superhuman_mail/attestation.py
@@ -14,6 +14,7 @@ from datetime import datetime, timedelta, timezone
 from email.utils import parseaddr
 from pathlib import Path
 from typing import Any, Protocol
+from urllib.parse import urlparse
 
 from ._state import private_file, state_dir
 
@@ -22,14 +23,33 @@ ADAPTER_VERSION = "superhuman-cdp-v1"
 DEFAULT_TTL_SECONDS = 15 * 60
 DEFAULT_CDP_URL = "http://127.0.0.1:9222"
 DEFAULT_ALLOWED_RENDERER_BUILDS = {("1041.0.15", "2026-07-09T19:06:39Z")}
-_WRITE_URL_MARKERS = (
-    "/messages/send",
-    "userdata.writemessage",
-    "attachments.upload",
-    "comments.",
-    "cancel",
-    "postpone",
-    "unschedule",
+_ATTACHMENT_HOST_SUFFIXES = (
+    ".googleapis.com",
+    ".googleusercontent.com",
+    ".superhuman.com",
+    ".firebaseio.com",
+)
+_READ_ONLY_POST_ACTIONS = (
+    "userdata.getthreads",
+    "userdata.read",
+    "userdata.searchhistory",
+    "userdata.sync",
+    "autolabels.preview",
+    "labels.recentchanges",
+    "labels.resync",
+    "autodrafts.previeweascheduling",
+    "smartsend.gettimerange",
+    "sessions.getcsrftoken",
+    "sessions.gettokens",
+    "teams.caninvite",
+    "teams.classify",
+    "teams.getbillingfeaturesbysku",
+    "teams.members",
+    "teams.suggest",
+    "links.content",
+    "translate.detectlanguage",
+    "users.getreferral",
+    "users.refreshaliases",
 )
 
 
@@ -163,6 +183,16 @@ def attachment_digests(draft: dict[str, Any]) -> dict[str, str]:
                 "UNATTESTABLE_ATTACHMENT",
                 f"Attachment {identifier} has neither a stable provider digest nor readable bytes",
             )
+        parsed_url = urlparse(str(url))
+        hostname = (parsed_url.hostname or "").lower()
+        if parsed_url.scheme != "https" or not any(
+            hostname == suffix[1:] or hostname.endswith(suffix)
+            for suffix in _ATTACHMENT_HOST_SUFFIXES
+        ):
+            raise AttestationError(
+                "UNATTESTABLE_ATTACHMENT",
+                f"Attachment {identifier} uses a non-allowlisted byte source",
+            )
         try:
             request = urllib.request.Request(str(url), method="GET")
             digest_hash = hashlib.sha256()
@@ -179,29 +209,21 @@ def attachment_digests(draft: dict[str, Any]) -> dict[str, str]:
 
 
 def _renderer_build_allowed(app_version: str, web_version: str) -> bool:
-    raw_builds = os.environ.get("SHM_RENDERER_ALLOW_BUILDS")
-    if raw_builds:
-        allowed: set[tuple[str, str]] = set()
-        for item in raw_builds.split(","):
-            app, separator, web = item.strip().partition("@")
-            if separator and app and web:
-                allowed.add((app, web))
-        return (app_version, web_version) in allowed
-    # Web-only override is retained for deterministic fixture tests and must be
-    # an explicit operator choice; production defaults bind both versions.
-    raw_versions = os.environ.get("SHM_RENDERER_ALLOW_VERSIONS")
-    if raw_versions:
-        return web_version in {item.strip() for item in raw_versions.split(",") if item.strip()}
     return (app_version, web_version) in DEFAULT_ALLOWED_RENDERER_BUILDS
 
 
 def _network_writes(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Fail closed on every non-idempotent probe request not explicitly read-only."""
     blocked = []
     for event in events:
         method = str(event.get("method") or "GET").upper()
         url = str(event.get("url") or "").lower()
-        if method not in {"GET", "HEAD", "OPTIONS"} and any(marker in url for marker in _WRITE_URL_MARKERS):
-            blocked.append({"method": method, "url": url})
+        if method in {"GET", "HEAD", "OPTIONS"}:
+            continue
+        action = urlparse(url).path.rstrip("/").rsplit("/", 1)[-1]
+        if method == "POST" and action in _READ_ONLY_POST_ACTIONS:
+            continue
+        blocked.append({"method": method, "url": url})
     return blocked
 
 
@@ -221,6 +243,9 @@ class CdpRenderer:
         self.script = Path(__file__).with_name("renderer_probe.js")
 
     def probe(self, request: dict[str, Any], *, output_dir: Path) -> dict[str, Any]:
+        parsed_cdp = urlparse(self.cdp_url)
+        if parsed_cdp.scheme not in {"http", "https"} or parsed_cdp.hostname not in {"127.0.0.1", "::1", "localhost"}:
+            raise AttestationError("RENDERER_ENDPOINT_UNSAFE", "Exact renderer CDP endpoint must be loopback-local")
         output_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
         try:
             output_dir.chmod(0o700)
@@ -253,16 +278,6 @@ class CdpRenderer:
 
 
 def _attestation_key(*, create: bool) -> bytes:
-    env = os.environ.get("SHM_ATTESTATION_KEY")
-    if env:
-        try:
-            key = base64.urlsafe_b64decode(env.encode())
-        except Exception as exc:
-            raise AttestationError("ATTESTATION_KEY_INVALID", "SHM_ATTESTATION_KEY is not urlsafe base64") from exc
-        if len(key) < 32:
-            raise AttestationError("ATTESTATION_KEY_INVALID", "Attestation HMAC key must contain at least 32 bytes")
-        return key
-
     service = "superhuman-mail-attestation-v1"
     user = getpass.getuser()
     found = subprocess.run(
@@ -311,7 +326,41 @@ def _seal(record: dict[str, Any]) -> dict[str, Any]:
     return {**with_id, "signature": f"hmac-sha256:{signature}"}
 
 
+def _validate_record_structure(record: dict[str, Any]) -> None:
+    required_scalars = (
+        "attestation_id",
+        "signature",
+        "created_at",
+        "expires_at",
+        "thread_id",
+        "draft_id",
+        "superhuman_id",
+    )
+    required_dicts = ("account", "fingerprint", "renderer", "source", "outgoing_payload")
+    if any(not isinstance(record.get(key), str) or not record.get(key) for key in required_scalars):
+        raise AttestationError("ATTESTATION_INVALID", "Attestation is missing required scalar fields")
+    if any(not isinstance(record.get(key), dict) for key in required_dicts):
+        raise AttestationError("ATTESTATION_INVALID", "Attestation is missing required object fields")
+    if not all((record["account"].get("email"), record["account"].get("provider_user_id"))):
+        raise AttestationError("ATTESTATION_INVALID", "Attestation account binding is malformed")
+    if not record["fingerprint"].get("exact"):
+        raise AttestationError("ATTESTATION_INVALID", "Attestation fingerprint is malformed")
+    if not all((record["renderer"].get("adapter_version"), record["renderer"].get("app_version"), record["renderer"].get("web_version"))):
+        raise AttestationError("ATTESTATION_INVALID", "Attestation renderer binding is malformed")
+    if not isinstance(record.get("screenshots"), list) or any(
+        not isinstance(item, dict) for item in record["screenshots"]
+    ):
+        raise AttestationError("ATTESTATION_INVALID", "Attestation screenshots are malformed")
+    if not isinstance(record.get("send_eligible"), bool):
+        raise AttestationError("ATTESTATION_INVALID", "Attestation eligibility is malformed")
+    try:
+        _parse_iso(record["expires_at"])
+    except (TypeError, ValueError) as exc:
+        raise AttestationError("ATTESTATION_INVALID", "Attestation expiry is malformed") from exc
+
+
 def verify(record: dict[str, Any], *, require_unexpired: bool = True) -> None:
+    _validate_record_structure(record)
     expected_id = hashlib.sha256(canonical_bytes(_unsigned(record))).hexdigest()
     if not hmac.compare_digest(str(record.get("attestation_id") or ""), expected_id):
         raise AttestationError("ATTESTATION_TAMPERED", "Attestation ID does not match its canonical content")
@@ -365,11 +414,14 @@ def save(record: dict[str, Any], *, output_dir: Path | None = None) -> Path:
 
 
 def load(reference: str | Path) -> dict[str, Any]:
-    candidate = Path(reference).expanduser()
-    if not candidate.exists():
-        candidate = _artifact_dir() / f"{reference}.json"
-    if not candidate.exists():
-        raise AttestationError("ATTESTATION_NOT_FOUND", f"Attestation not found: {reference}")
+    try:
+        candidate = Path(reference).expanduser()
+        if not candidate.exists():
+            candidate = _artifact_dir() / f"{reference}.json"
+        if not candidate.exists():
+            raise AttestationError("ATTESTATION_NOT_FOUND", f"Attestation not found: {reference}")
+    except OSError as exc:
+        raise AttestationError("ATTESTATION_NOT_FOUND", "Attestation reference is not a valid local path or ID") from exc
     try:
         record = json.loads(candidate.read_text())
     except (OSError, json.JSONDecodeError) as exc:

--- a/superhuman_mail/attestation.py
+++ b/superhuman_mail/attestation.py
@@ -1,0 +1,702 @@
+"""Exact Superhuman renderer attestation and send-time stale verification."""
+from __future__ import annotations
+
+import base64
+import getpass
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import subprocess
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from email.utils import parseaddr
+from pathlib import Path
+from typing import Any, Protocol
+
+from ._state import private_file, state_dir
+
+SCHEMA_VERSION = 1
+ADAPTER_VERSION = "superhuman-cdp-v1"
+DEFAULT_TTL_SECONDS = 15 * 60
+DEFAULT_CDP_URL = "http://127.0.0.1:9222"
+DEFAULT_ALLOWED_WEB_VERSIONS = {"2026-07-09T19:06:39Z"}
+_WRITE_URL_MARKERS = (
+    "/messages/send",
+    "userdata.writemessage",
+    "attachments.upload",
+    "comments.",
+    "cancel",
+    "postpone",
+    "unschedule",
+)
+
+
+class AttestationError(RuntimeError):
+    """An exact render could not be safely attested or verified."""
+
+    def __init__(self, code: str, hint: str) -> None:
+        super().__init__(hint)
+        self.code = code
+        self.hint = hint
+
+
+class Renderer(Protocol):
+    def probe(self, request: dict[str, Any], *, output_dir: Path) -> dict[str, Any]: ...
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def _parse_iso(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode()
+
+
+def sha256(value: bytes | str) -> str:
+    data = value.encode() if isinstance(value, str) else value
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def _normalize_contact(value: Any) -> dict[str, str]:
+    if isinstance(value, dict):
+        email = str(value.get("email") or value.get("emailAddress") or "").strip().lower()
+        return {"email": email}
+    _name, email = parseaddr(str(value or "").strip())
+    return {"email": (email or str(value or "")).strip().lower()}
+
+
+def _attachment_metadata(item: dict[str, Any]) -> dict[str, Any]:
+    source = item.get("source") or {}
+    return {
+        "uuid": item.get("uuid"),
+        "cid": item.get("cid"),
+        "name": item.get("name"),
+        "type": item.get("type"),
+        "size": item.get("size"),
+        "inline": bool(item.get("inline")),
+        "source": {
+            "type": source.get("type"),
+            "thread_id": source.get("threadId") or source.get("thread_id"),
+            "message_id": source.get("messageId") or source.get("message_id"),
+            "attachment_id": source.get("attachmentId") or source.get("attachment_id"),
+            "fixed_part_id": source.get("fixedPartId") or source.get("fixed_part_id"),
+            "uuid": source.get("uuid"),
+            "cid": source.get("cid"),
+        },
+    }
+
+
+def source_fields(draft: dict[str, Any], *, attachment_digests: dict[str, str] | None = None) -> dict[str, Any]:
+    """Canonical send-affecting source fields, excluding observational clocks."""
+    digests = attachment_digests or {}
+    attachments = []
+    for item in sorted((draft.get("attachments") or []), key=lambda value: str(value.get("uuid") or "")):
+        metadata = _attachment_metadata(item)
+        metadata["digest"] = digests.get(str(item.get("uuid") or ""))
+        attachments.append(metadata)
+    return {
+        "id": str(draft.get("id") or ""),
+        "thread_id": str(draft.get("threadId") or draft.get("thread_id") or ""),
+        "action": draft.get("action"),
+        "from": _normalize_contact(draft.get("from")),
+        "to": [_normalize_contact(value) for value in (draft.get("to") or [])],
+        "cc": [_normalize_contact(value) for value in (draft.get("cc") or [])],
+        "bcc": [_normalize_contact(value) for value in (draft.get("bcc") or [])],
+        "subject": str(draft.get("subject") or ""),
+        "body": str(draft.get("htmlBody") or draft.get("body") or ""),
+        "quoted_content": str(draft.get("quotedContent") or ""),
+        "quoted_content_inlined": bool(draft.get("quotedContentInlined")),
+        "in_reply_to": draft.get("inReplyTo"),
+        "in_reply_to_rfc822_id": draft.get("inReplyToRfc822Id"),
+        "references": list(draft.get("references") or []),
+        "rfc822_id": draft.get("rfc822Id"),
+        "scheduled_for": draft.get("scheduledFor"),
+        "abort_on_reply": bool(draft.get("abortOnReply")),
+        "reminder": draft.get("reminder"),
+        "sensitivity_label_id": draft.get("sensitivityLabelId"),
+        "sensitivity_tenant_id": draft.get("sensitivityTenantId"),
+        "attachments": attachments,
+    }
+
+
+def _digest_from_metadata(attachment: dict[str, Any]) -> str | None:
+    for key in ("sha256", "contentSha256", "contentHash", "digest"):
+        value = attachment.get(key)
+        if value:
+            text = str(value)
+            return text if ":" in text else f"provider:{text}"
+    source = attachment.get("source") or {}
+    for key in ("sha256", "contentSha256", "contentHash", "digest"):
+        value = source.get(key)
+        if value:
+            text = str(value)
+            return text if ":" in text else f"provider:{text}"
+    return None
+
+
+def attachment_digests(draft: dict[str, Any]) -> dict[str, str]:
+    """Obtain re-verifiable bytes/digests or fail closed."""
+    results: dict[str, str] = {}
+    for attachment in draft.get("attachments") or []:
+        identifier = str(attachment.get("uuid") or "")
+        if not identifier:
+            raise AttestationError("UNATTESTABLE_ATTACHMENT", "Attachment has no stable UUID")
+        digest = _digest_from_metadata(attachment)
+        if digest:
+            results[identifier] = digest
+            continue
+        source = attachment.get("source") or {}
+        url = source.get("url") or attachment.get("downloadUrl")
+        if not url:
+            raise AttestationError(
+                "UNATTESTABLE_ATTACHMENT",
+                f"Attachment {identifier} has neither a stable provider digest nor readable bytes",
+            )
+        try:
+            request = urllib.request.Request(str(url), method="GET")
+            with urllib.request.urlopen(request, timeout=30) as response:
+                results[identifier] = sha256(response.read())
+        except Exception as exc:
+            raise AttestationError(
+                "UNATTESTABLE_ATTACHMENT",
+                f"Could not read bytes for attachment {identifier}: {type(exc).__name__}",
+            ) from exc
+    return results
+
+
+def _allowed_versions() -> set[str]:
+    raw = os.environ.get("SHM_RENDERER_ALLOW_VERSIONS")
+    return {item.strip() for item in raw.split(",") if item.strip()} if raw else set(DEFAULT_ALLOWED_WEB_VERSIONS)
+
+
+def _network_writes(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    blocked = []
+    for event in events:
+        method = str(event.get("method") or "GET").upper()
+        url = str(event.get("url") or "").lower()
+        if method not in {"GET", "HEAD", "OPTIONS"} and any(marker in url for marker in _WRITE_URL_MARKERS):
+            blocked.append({"method": method, "url": url})
+    return blocked
+
+
+class CdpRenderer:
+    """Invoke the bundled, version-gated read-only Superhuman CDP probe."""
+
+    def __init__(
+        self,
+        *,
+        cdp_url: str | None = None,
+        window_id: int | str | None = None,
+        timeout: int = 60,
+    ) -> None:
+        self.cdp_url = cdp_url or os.environ.get("SHM_RENDERER_CDP_URL") or DEFAULT_CDP_URL
+        self.window_id = window_id or os.environ.get("SHM_RENDERER_WINDOW_ID")
+        self.timeout = timeout
+        self.script = Path(__file__).with_name("renderer_probe.js")
+
+    def probe(self, request: dict[str, Any], *, output_dir: Path) -> dict[str, Any]:
+        output_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        try:
+            output_dir.chmod(0o700)
+        except OSError:
+            pass
+        command = ["node", str(self.script), "--cdp", self.cdp_url, "--output", str(output_dir)]
+        probe_request = {**request}
+        if self.window_id is not None:
+            probe_request["window_id"] = str(self.window_id)
+        try:
+            completed = subprocess.run(
+                command,
+                input=canonical_bytes(probe_request),
+                capture_output=True,
+                timeout=self.timeout,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise AttestationError("RENDERER_UNAVAILABLE", f"Could not run exact renderer probe: {exc}") from exc
+        if completed.returncode != 0:
+            detail = completed.stderr.decode(errors="replace").strip()[:500]
+            raise AttestationError("RENDERER_FAILED", detail or "Exact renderer probe failed")
+        try:
+            value = json.loads(completed.stdout)
+        except json.JSONDecodeError as exc:
+            raise AttestationError("RENDERER_FAILED", "Exact renderer probe returned invalid JSON") from exc
+        if not isinstance(value, dict):
+            raise AttestationError("RENDERER_FAILED", "Exact renderer probe returned a non-object")
+        return value
+
+
+def _attestation_key(*, create: bool) -> bytes:
+    env = os.environ.get("SHM_ATTESTATION_KEY")
+    if env:
+        try:
+            key = base64.urlsafe_b64decode(env.encode())
+        except Exception as exc:
+            raise AttestationError("ATTESTATION_KEY_INVALID", "SHM_ATTESTATION_KEY is not urlsafe base64") from exc
+        if len(key) < 32:
+            raise AttestationError("ATTESTATION_KEY_INVALID", "Attestation HMAC key must contain at least 32 bytes")
+        return key
+
+    service = "superhuman-mail-attestation-v1"
+    user = getpass.getuser()
+    found = subprocess.run(
+        ["security", "find-generic-password", "-a", user, "-s", service, "-w"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if found.returncode == 0 and found.stdout.strip():
+        try:
+            key = base64.urlsafe_b64decode(found.stdout.strip().encode())
+        except Exception as exc:
+            raise AttestationError("ATTESTATION_KEY_INVALID", "Keychain attestation key is invalid") from exc
+        if len(key) < 32:
+            raise AttestationError("ATTESTATION_KEY_INVALID", "Keychain attestation key is too short")
+        return key
+    if not create:
+        raise AttestationError("ATTESTATION_KEY_MISSING", "Local attestation key is missing from Keychain")
+    key = secrets.token_bytes(32)
+    encoded = base64.urlsafe_b64encode(key).decode()
+    added = subprocess.run(
+        ["security", "add-generic-password", "-U", "-a", user, "-s", service, "-w", encoded],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if added.returncode != 0:
+        raise AttestationError("ATTESTATION_KEY_MISSING", "Could not create local attestation key in Keychain")
+    return key
+
+
+def _unsigned(record: dict[str, Any]) -> dict[str, Any]:
+    # artifact_path is local presentation metadata added after sealing.
+    return {
+        key: value
+        for key, value in record.items()
+        if key not in {"attestation_id", "signature", "artifact_path"}
+    }
+
+
+def _seal(record: dict[str, Any]) -> dict[str, Any]:
+    unsigned = _unsigned(record)
+    attestation_id = hashlib.sha256(canonical_bytes(unsigned)).hexdigest()
+    with_id = {**unsigned, "attestation_id": attestation_id}
+    signature = hmac.new(_attestation_key(create=True), canonical_bytes(with_id), hashlib.sha256).hexdigest()
+    return {**with_id, "signature": f"hmac-sha256:{signature}"}
+
+
+def verify(record: dict[str, Any], *, require_unexpired: bool = True) -> None:
+    expected_id = hashlib.sha256(canonical_bytes(_unsigned(record))).hexdigest()
+    if not hmac.compare_digest(str(record.get("attestation_id") or ""), expected_id):
+        raise AttestationError("ATTESTATION_TAMPERED", "Attestation ID does not match its canonical content")
+    signature = str(record.get("signature") or "")
+    expected_signature = "hmac-sha256:" + hmac.new(
+        _attestation_key(create=False),
+        canonical_bytes({**_unsigned(record), "attestation_id": expected_id}),
+        hashlib.sha256,
+    ).hexdigest()
+    if not hmac.compare_digest(signature, expected_signature):
+        raise AttestationError("ATTESTATION_TAMPERED", "Attestation signature is invalid")
+    if require_unexpired and _parse_iso(str(record["expires_at"])) <= _now():
+        raise AttestationError("ATTESTATION_EXPIRED", "Render attestation has expired; preview and approve again")
+    if not record.get("send_eligible"):
+        raise AttestationError("ATTESTATION_NOT_SEND_ELIGIBLE", "Attestation was not marked send-eligible")
+
+
+def _artifact_dir() -> Path:
+    path = state_dir() / "attestations"
+    path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    try:
+        path.chmod(0o700)
+    except OSError:
+        pass
+    return path
+
+
+def save(record: dict[str, Any], *, output_dir: Path | None = None) -> Path:
+    attestation_id = str(record["attestation_id"])
+    canonical_path = _artifact_dir() / f"{attestation_id}.json"
+    canonical_path.write_bytes(canonical_bytes(record) + b"\n")
+    private_file(canonical_path)
+    if output_dir is not None:
+        output_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        try:
+            output_dir.chmod(0o700)
+        except OSError:
+            pass
+        copy_path = output_dir / "attestation.json"
+        copy_path.write_bytes(canonical_bytes(record) + b"\n")
+        private_file(copy_path)
+    return canonical_path
+
+
+def load(reference: str | Path) -> dict[str, Any]:
+    candidate = Path(reference).expanduser()
+    if not candidate.exists():
+        candidate = _artifact_dir() / f"{reference}.json"
+    if not candidate.exists():
+        raise AttestationError("ATTESTATION_NOT_FOUND", f"Attestation not found: {reference}")
+    try:
+        record = json.loads(candidate.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AttestationError("ATTESTATION_INVALID", f"Cannot read attestation: {reference}") from exc
+    if not isinstance(record, dict):
+        raise AttestationError("ATTESTATION_INVALID", "Attestation must be a JSON object")
+    return record
+
+
+def show_safe(
+    reference: str | Path,
+    *,
+    account: str | None = None,
+    thread_id: str | None = None,
+    draft_id: str | None = None,
+) -> dict[str, Any]:
+    """Verify and return a deliberately content-free local summary."""
+    record = load(reference)
+    verify(record, require_unexpired=False)
+    record_account = str((record.get("account") or {}).get("email") or "")
+    bindings = {
+        "account": account is None or record_account.lower() == account.lower(),
+        "thread_id": thread_id is None or str(record.get("thread_id")) == thread_id,
+        "draft_id": draft_id is None or str(record.get("draft_id")) == draft_id,
+    }
+    checked = any(value is not None for value in (account, thread_id, draft_id))
+    if checked and not all(bindings.values()):
+        mismatched = ", ".join(key for key, matches in bindings.items() if not matches)
+        raise AttestationError("ATTESTATION_BINDING_MISMATCH", f"Attestation differs from requested {mismatched}")
+
+    expired = _parse_iso(str(record["expires_at"])) <= _now()
+    source = record.get("source") or {}
+    return {
+        "attestation_id": record["attestation_id"],
+        "signature_valid": True,
+        "created_at": record["created_at"],
+        "expires_at": record["expires_at"],
+        "expired": expired,
+        "usable": bool(record.get("send_eligible")) and not expired,
+        "send_eligible": bool(record.get("send_eligible")),
+        "confidence": record.get("confidence"),
+        "account_email": record_account,
+        "thread_id": record.get("thread_id"),
+        "draft_id": record.get("draft_id"),
+        "binding_match": all(bindings.values()) if checked else None,
+        "delay_seconds": record.get("delay_seconds"),
+        "fingerprint": (record.get("fingerprint") or {}).get("exact"),
+        "renderer": dict(record.get("renderer") or {}),
+        "screenshots": [
+            {"path": item.get("path"), "sha256": item.get("sha256")}
+            for item in (record.get("screenshots") or [])
+        ],
+        "summary": {
+            "to_count": len(source.get("to") or []),
+            "cc_count": len(source.get("cc") or []),
+            "bcc_count": len(source.get("bcc") or []),
+            "attachment_count": len(source.get("attachments") or []),
+            "empty_subject": not bool(str(source.get("subject") or "").strip()),
+            "scheduled": bool(source.get("scheduled_for")),
+            "has_quote": bool(source.get("quoted_content")),
+        },
+    }
+
+
+def _screenshot_records(result: dict[str, Any]) -> list[dict[str, str]]:
+    records = []
+    for raw_path in result.get("screenshots") or []:
+        path = Path(str(raw_path))
+        if not path.exists():
+            raise AttestationError("RENDERER_FAILED", f"Renderer screenshot is missing: {path}")
+        private_file(path)
+        records.append({"path": str(path), "sha256": sha256(path.read_bytes())})
+    return records
+
+
+def _validate_probe(
+    result: dict[str, Any],
+    *,
+    expected_account: dict[str, str],
+    thread_id: str,
+    draft_id: str,
+    sid: str,
+    expected_source: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    if result.get("dirty") is not False:
+        raise AttestationError("DIRTY_RENDERER_DRAFT", "Live Superhuman draft/editor has unsaved state")
+    if str(result.get("thread_id") or "") != thread_id or str(result.get("draft_id") or "") != draft_id:
+        raise AttestationError("RENDERER_DRAFT_MISMATCH", "Live Superhuman renderer is not on the requested draft/thread")
+    if str(result.get("account_email") or "").lower() != expected_account["email"].lower():
+        raise AttestationError("RENDERER_ACCOUNT_MISMATCH", "Live Superhuman renderer is bound to a different account")
+
+    live_json = result.get("live_draft_json")
+    if not isinstance(live_json, dict):
+        raise AttestationError("RENDERER_FAILED", "Renderer did not return the live draft model JSON")
+    live_source = source_fields(live_json, attachment_digests={
+        str(item.get("uuid") or ""): str(item.get("digest"))
+        for item in expected_source.get("attachments") or []
+        if item.get("digest")
+    })
+    if canonical_bytes(live_source) != canonical_bytes(expected_source):
+        raise AttestationError("RENDERER_SOURCE_MISMATCH", "Live Superhuman model differs from the selected server draft")
+
+    payload = result.get("outgoing_payload")
+    if not isinstance(payload, dict):
+        raise AttestationError("RENDERER_FAILED", "Renderer did not return OutgoingMessage.toJsonRequest()")
+    if str(payload.get("superhuman_id") or "") != sid:
+        raise AttestationError("RENDERER_IDENTITY_MISMATCH", "Renderer did not reuse the reserved Superhuman identity")
+    if str(payload.get("thread_id") or "") != thread_id or str(payload.get("message_id") or "") != draft_id:
+        raise AttestationError("RENDERER_PAYLOAD_MISMATCH", "Outgoing payload is not bound to the requested draft/thread")
+    if _network_writes(list(result.get("network_events") or [])):
+        raise AttestationError("RENDERER_WROTE_LIVE_STATE", "Renderer probe observed a prohibited write request")
+
+    version = str(result.get("web_version") or "")
+    if version not in _allowed_versions():
+        raise AttestationError("RENDERER_VERSION_UNSUPPORTED", f"Superhuman web code version is not allowlisted: {version or 'unknown'}")
+    return live_source, payload
+
+
+def _fingerprint(
+    *,
+    account: dict[str, str],
+    source: dict[str, Any],
+    editor_html: str,
+    payload: dict[str, Any],
+    signature_settings: Any,
+    app_version: str,
+    web_version: str,
+    history_id: Any,
+    delay: int,
+) -> dict[str, Any]:
+    fields = {
+        "account": sha256(canonical_bytes(account)),
+        "source": sha256(canonical_bytes(source)),
+        "raw_body": sha256(source["body"]),
+        "editor_html": sha256(editor_html),
+        "outgoing_payload": sha256(canonical_bytes(payload)),
+        "signature_settings": sha256(canonical_bytes(signature_settings)),
+        "renderer_versions": sha256(canonical_bytes({"app": app_version, "web": web_version, "adapter": ADAPTER_VERSION})),
+        "history_id": sha256(canonical_bytes(history_id)),
+        "transport": sha256(canonical_bytes({"version": 3, "delay": delay, "is_multi_recipient": True})),
+    }
+    return {"fields": fields, "exact": sha256(canonical_bytes(fields))}
+
+
+def create(
+    thread_id: str,
+    draft_id: str,
+    *,
+    account: str,
+    output_dir: Path,
+    delay: int = 20,
+    renderer: Renderer | None = None,
+    ttl_seconds: int = DEFAULT_TTL_SECONDS,
+) -> dict[str, Any]:
+    """Create a signed attestation without calling any mail write/send endpoint."""
+    from . import send  # avoid import cycle
+
+    renderer = renderer or CdpRenderer()
+    sid = send._superhuman_id()
+    checked_a = send._preflight(
+        thread_id,
+        draft_id,
+        account=account,
+        sid=sid,
+        require_explicit_account=True,
+        allow_empty_subject=True,
+    )
+    draft_a = checked_a["draft"]
+    digests_a = attachment_digests(draft_a)
+    source_a = source_fields(draft_a, attachment_digests=digests_a)
+    history_a = checked_a["lifecycle"]["observations"][0].get("history_id")
+
+    request = {
+        "schema_version": SCHEMA_VERSION,
+        "adapter_version": ADAPTER_VERSION,
+        "account_email": checked_a["lifecycle"]["account"]["email"],
+        "provider_user_id": checked_a["lifecycle"]["account"]["provider_user_id"],
+        "thread_id": thread_id,
+        "draft_id": draft_id,
+        "superhuman_id": sid,
+        "expected_source_sha256": sha256(canonical_bytes(source_a)),
+    }
+    probe = renderer.probe(request, output_dir=output_dir)
+    live_source, payload = _validate_probe(
+        probe,
+        expected_account=checked_a["lifecycle"]["account"],
+        thread_id=thread_id,
+        draft_id=draft_id,
+        sid=sid,
+        expected_source=source_a,
+    )
+
+    checked_b = send._preflight(
+        thread_id,
+        draft_id,
+        account=account,
+        sid=sid,
+        require_explicit_account=True,
+        allow_empty_subject=True,
+    )
+    digests_b = attachment_digests(checked_b["draft"])
+    source_b = source_fields(checked_b["draft"], attachment_digests=digests_b)
+    history_b = checked_b["lifecycle"]["observations"][0].get("history_id")
+    if canonical_bytes(source_a) != canonical_bytes(source_b) or history_a != history_b:
+        raise AttestationError("DRAFT_CHANGED_DURING_RENDER", "Server draft/history changed during the renderer probe")
+
+    editor_html = str(probe.get("editor_html") or "")
+    if not editor_html:
+        raise AttestationError("RENDERER_FAILED", "Renderer did not return editor-normalized HTML")
+    app_version = str(probe.get("app_version") or "")
+    web_version = str(probe.get("web_version") or "")
+    signature_settings = probe.get("signature_settings") or {}
+    fingerprint = _fingerprint(
+        account=checked_a["lifecycle"]["account"],
+        source=live_source,
+        editor_html=editor_html,
+        payload=payload,
+        signature_settings=signature_settings,
+        app_version=app_version,
+        web_version=web_version,
+        history_id=history_a,
+        delay=delay,
+    )
+    created_at = _now()
+    record = _seal({
+        "schema_version": SCHEMA_VERSION,
+        "created_at": _iso(created_at),
+        "expires_at": _iso(created_at + timedelta(seconds=ttl_seconds)),
+        "send_eligible": True,
+        "confidence": "exact_superhuman_renderer",
+        "account": checked_a["lifecycle"]["account"],
+        "thread_id": thread_id,
+        "draft_id": draft_id,
+        "superhuman_id": sid,
+        "delay_seconds": delay,
+        "source": live_source,
+        "editor_html": editor_html,
+        "outgoing_payload": payload,
+        "signature_settings": signature_settings,
+        "renderer": {
+            "adapter_version": ADAPTER_VERSION,
+            "app_version": app_version,
+            "web_version": web_version,
+            "surface": probe.get("surface") or "superhuman-desktop",
+        },
+        "history_id": history_a,
+        "fingerprint": fingerprint,
+        "screenshots": _screenshot_records(probe),
+        "observation": {"attested_at": _iso(created_at)},
+    })
+    path = save(record, output_dir=output_dir)
+    return {**record, "artifact_path": str(path)}
+
+
+def revalidate_for_send(
+    record: dict[str, Any],
+    *,
+    account: str,
+    renderer: Renderer | None = None,
+    output_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Second no-write probe; return only freshly verified payload bytes."""
+    from . import send  # avoid import cycle
+
+    verify(record)
+    renderer = renderer or CdpRenderer()
+    output_dir = output_dir or (_artifact_dir() / str(record["attestation_id"]) / "send-time")
+    if record["account"]["email"].lower() != account.lower():
+        raise AttestationError("ACCOUNT_BINDING_MISMATCH", "Send account differs from the approved attestation")
+
+    checked_a = send._preflight(
+        str(record["thread_id"]),
+        str(record["draft_id"]),
+        account=account,
+        sid=str(record["superhuman_id"]),
+        require_explicit_account=True,
+        allow_empty_subject=not bool(str(record["source"].get("subject") or "").strip()),
+        attempt_superhuman_id=str(record["superhuman_id"]),
+    )
+    digests = attachment_digests(checked_a["draft"])
+    current_source = source_fields(checked_a["draft"], attachment_digests=digests)
+    history_a = checked_a["lifecycle"]["observations"][0].get("history_id")
+    if canonical_bytes(current_source) != canonical_bytes(record["source"]):
+        raise AttestationError("STALE_ATTESTATION", "Server draft differs from the approved source")
+    if history_a != record.get("history_id"):
+        raise AttestationError("STALE_ATTESTATION", "Server history changed after approval")
+
+    request = {
+        "schema_version": SCHEMA_VERSION,
+        "adapter_version": ADAPTER_VERSION,
+        "account_email": record["account"]["email"],
+        "provider_user_id": record["account"]["provider_user_id"],
+        "thread_id": record["thread_id"],
+        "draft_id": record["draft_id"],
+        "superhuman_id": record["superhuman_id"],
+        "expected_source_sha256": sha256(canonical_bytes(record["source"])),
+    }
+    probe = renderer.probe(request, output_dir=output_dir)
+    live_source, payload = _validate_probe(
+        probe,
+        expected_account=record["account"],
+        thread_id=str(record["thread_id"]),
+        draft_id=str(record["draft_id"]),
+        sid=str(record["superhuman_id"]),
+        expected_source=record["source"],
+    )
+
+    checked_b = send._preflight(
+        str(record["thread_id"]),
+        str(record["draft_id"]),
+        account=account,
+        sid=str(record["superhuman_id"]),
+        require_explicit_account=True,
+        allow_empty_subject=not bool(str(record["source"].get("subject") or "").strip()),
+        attempt_superhuman_id=str(record["superhuman_id"]),
+    )
+    source_b = source_fields(checked_b["draft"], attachment_digests=attachment_digests(checked_b["draft"]))
+    history_b = checked_b["lifecycle"]["observations"][0].get("history_id")
+    if canonical_bytes(current_source) != canonical_bytes(source_b) or history_a != history_b:
+        raise AttestationError("STALE_ATTESTATION", "Server draft/history changed during send-time rendering")
+
+    fingerprint = _fingerprint(
+        account=record["account"],
+        source=live_source,
+        editor_html=str(probe.get("editor_html") or ""),
+        payload=payload,
+        signature_settings=probe.get("signature_settings") or {},
+        app_version=str(probe.get("app_version") or ""),
+        web_version=str(probe.get("web_version") or ""),
+        history_id=history_b,
+        delay=int(record["delay_seconds"]),
+    )
+    if not hmac.compare_digest(fingerprint["exact"], str(record["fingerprint"]["exact"])):
+        changed = sorted(
+            key
+            for key, approved in record["fingerprint"]["fields"].items()
+            if fingerprint["fields"].get(key) != approved
+        )
+        raise AttestationError(
+            "STALE_ATTESTATION",
+            "Exact renderer output changed after approval" + (f" ({', '.join(changed)})" if changed else ""),
+        )
+    if canonical_bytes(payload) != canonical_bytes(record["outgoing_payload"]):
+        raise AttestationError("STALE_ATTESTATION", "Fresh outgoing payload bytes differ from approval")
+
+    return {
+        "outgoing_payload": payload,
+        "outgoing_payload_bytes": canonical_bytes(payload),
+        "fingerprint": fingerprint,
+        "observation": {"send_time_probed_at": _iso(_now())},
+        "screenshots": _screenshot_records(probe),
+        "preflight": checked_b,
+    }

--- a/superhuman_mail/attestation.py
+++ b/superhuman_mail/attestation.py
@@ -21,7 +21,7 @@ SCHEMA_VERSION = 1
 ADAPTER_VERSION = "superhuman-cdp-v1"
 DEFAULT_TTL_SECONDS = 15 * 60
 DEFAULT_CDP_URL = "http://127.0.0.1:9222"
-DEFAULT_ALLOWED_WEB_VERSIONS = {"2026-07-09T19:06:39Z"}
+DEFAULT_ALLOWED_RENDERER_BUILDS = {("1041.0.15", "2026-07-09T19:06:39Z")}
 _WRITE_URL_MARKERS = (
     "/messages/send",
     "userdata.writemessage",
@@ -165,8 +165,11 @@ def attachment_digests(draft: dict[str, Any]) -> dict[str, str]:
             )
         try:
             request = urllib.request.Request(str(url), method="GET")
+            digest_hash = hashlib.sha256()
             with urllib.request.urlopen(request, timeout=30) as response:
-                results[identifier] = sha256(response.read())
+                while chunk := response.read(1024 * 1024):
+                    digest_hash.update(chunk)
+            results[identifier] = "sha256:" + digest_hash.hexdigest()
         except Exception as exc:
             raise AttestationError(
                 "UNATTESTABLE_ATTACHMENT",
@@ -175,9 +178,21 @@ def attachment_digests(draft: dict[str, Any]) -> dict[str, str]:
     return results
 
 
-def _allowed_versions() -> set[str]:
-    raw = os.environ.get("SHM_RENDERER_ALLOW_VERSIONS")
-    return {item.strip() for item in raw.split(",") if item.strip()} if raw else set(DEFAULT_ALLOWED_WEB_VERSIONS)
+def _renderer_build_allowed(app_version: str, web_version: str) -> bool:
+    raw_builds = os.environ.get("SHM_RENDERER_ALLOW_BUILDS")
+    if raw_builds:
+        allowed: set[tuple[str, str]] = set()
+        for item in raw_builds.split(","):
+            app, separator, web = item.strip().partition("@")
+            if separator and app and web:
+                allowed.add((app, web))
+        return (app_version, web_version) in allowed
+    # Web-only override is retained for deterministic fixture tests and must be
+    # an explicit operator choice; production defaults bind both versions.
+    raw_versions = os.environ.get("SHM_RENDERER_ALLOW_VERSIONS")
+    if raw_versions:
+        return web_version in {item.strip() for item in raw_versions.split(",") if item.strip()}
+    return (app_version, web_version) in DEFAULT_ALLOWED_RENDERER_BUILDS
 
 
 def _network_writes(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -308,6 +323,14 @@ def verify(record: dict[str, Any], *, require_unexpired: bool = True) -> None:
     ).hexdigest()
     if not hmac.compare_digest(signature, expected_signature):
         raise AttestationError("ATTESTATION_TAMPERED", "Attestation signature is invalid")
+    for screenshot in record.get("screenshots") or []:
+        path = Path(str(screenshot.get("path") or ""))
+        expected_hash = str(screenshot.get("sha256") or "")
+        if not path.is_file() or not expected_hash or not hmac.compare_digest(sha256(path.read_bytes()), expected_hash):
+            raise AttestationError(
+                "ATTESTATION_ARTIFACT_MISMATCH",
+                "An attested screenshot is missing or differs from its signed hash",
+            )
     if require_unexpired and _parse_iso(str(record["expires_at"])) <= _now():
         raise AttestationError("ATTESTATION_EXPIRED", "Render attestation has expired; preview and approve again")
     if not record.get("send_eligible"):
@@ -407,6 +430,7 @@ def show_safe(
             "empty_subject": not bool(str(source.get("subject") or "").strip()),
             "scheduled": bool(source.get("scheduled_for")),
             "has_quote": bool(source.get("quoted_content")),
+            "editor_normalized_changed": bool((record.get("normalization") or {}).get("changed")),
         },
     }
 
@@ -459,9 +483,13 @@ def _validate_probe(
     if _network_writes(list(result.get("network_events") or [])):
         raise AttestationError("RENDERER_WROTE_LIVE_STATE", "Renderer probe observed a prohibited write request")
 
-    version = str(result.get("web_version") or "")
-    if version not in _allowed_versions():
-        raise AttestationError("RENDERER_VERSION_UNSUPPORTED", f"Superhuman web code version is not allowlisted: {version or 'unknown'}")
+    app_version = str(result.get("app_version") or "")
+    web_version = str(result.get("web_version") or "")
+    if not _renderer_build_allowed(app_version, web_version):
+        raise AttestationError(
+            "RENDERER_VERSION_UNSUPPORTED",
+            f"Superhuman renderer build is not allowlisted: {app_version or 'unknown'}@{web_version or 'unknown'}",
+        )
     return live_source, payload
 
 
@@ -584,6 +612,11 @@ def create(
         "delay_seconds": delay,
         "source": live_source,
         "editor_html": editor_html,
+        "normalization": {
+            "changed": source_a["body"].encode() != editor_html.encode(),
+            "raw_body_sha256": sha256(source_a["body"]),
+            "editor_html_sha256": sha256(editor_html),
+        },
         "outgoing_payload": payload,
         "signature_settings": signature_settings,
         "renderer": {

--- a/superhuman_mail/attestation.py
+++ b/superhuman_mail/attestation.py
@@ -454,6 +454,8 @@ def show_safe(
 
     expired = _parse_iso(str(record["expires_at"])) <= _now()
     source = record.get("source") or {}
+    from . import approval as _approval
+
     return {
         "attestation_id": record["attestation_id"],
         "signature_valid": True,
@@ -469,6 +471,7 @@ def show_safe(
         "binding_match": all(bindings.values()) if checked else None,
         "delay_seconds": record.get("delay_seconds"),
         "fingerprint": (record.get("fingerprint") or {}).get("exact"),
+        "approval_binding": _approval.binding_for_attestation(record),
         "renderer": dict(record.get("renderer") or {}),
         "screenshots": [
             {"path": item.get("path"), "sha256": item.get("sha256")}
@@ -571,6 +574,13 @@ def _fingerprint(
     return {"fields": fields, "exact": sha256(canonical_bytes(fields))}
 
 
+def _preflight_for_attestation(send_module: Any, *args: Any, **kwargs: Any) -> dict[str, Any]:
+    try:
+        return send_module._preflight(*args, **kwargs)
+    except send_module.SendSafetyError as exc:
+        raise AttestationError(exc.code, exc.hint) from exc
+
+
 def create(
     thread_id: str,
     draft_id: str,
@@ -586,7 +596,8 @@ def create(
 
     renderer = renderer or CdpRenderer()
     sid = send._superhuman_id()
-    checked_a = send._preflight(
+    checked_a = _preflight_for_attestation(
+        send,
         thread_id,
         draft_id,
         account=account,
@@ -619,7 +630,8 @@ def create(
         expected_source=source_a,
     )
 
-    checked_b = send._preflight(
+    checked_b = _preflight_for_attestation(
+        send,
         thread_id,
         draft_id,
         account=account,

--- a/superhuman_mail/attestation.py
+++ b/superhuman_mail/attestation.py
@@ -29,28 +29,32 @@ _ATTACHMENT_HOST_SUFFIXES = (
     ".superhuman.com",
     ".firebaseio.com",
 )
-_READ_ONLY_POST_ACTIONS = (
-    "userdata.getthreads",
-    "userdata.read",
-    "userdata.searchhistory",
-    "userdata.sync",
-    "autolabels.preview",
-    "labels.recentchanges",
-    "labels.resync",
-    "autodrafts.previeweascheduling",
-    "smartsend.gettimerange",
-    "sessions.getcsrftoken",
-    "sessions.gettokens",
-    "teams.caninvite",
-    "teams.classify",
-    "teams.getbillingfeaturesbysku",
-    "teams.members",
-    "teams.suggest",
-    "links.content",
-    "translate.detectlanguage",
-    "users.getreferral",
-    "users.refreshaliases",
-)
+_READ_ONLY_POST_ROUTES = {
+    "https://mail.superhuman.com": {
+        "/~backend/v3/userdata.getthreads",
+        "/~backend/v3/userdata.read",
+        "/~backend/v3/userdata.searchhistory",
+        "/~backend/v3/userdata.sync",
+        "/~backend/v3/autolabels.preview",
+        "/~backend/v3/labels.recentchanges",
+        "/~backend/v3/labels.resync",
+        "/~backend/v3/autodrafts.previeweascheduling",
+        "/~backend/v3/smartsend.gettimerange",
+        "/~backend/v3/teams.caninvite",
+        "/~backend/v3/teams.classify",
+        "/~backend/v3/teams.getbillingfeaturesbysku",
+        "/~backend/v3/teams.members",
+        "/~backend/v3/teams.suggest",
+        "/~backend/v3/links.content",
+        "/~backend/v3/translate.detectlanguage",
+        "/~backend/v3/users.getreferral",
+        "/~backend/v3/users.refreshaliases",
+    },
+    "https://accounts.superhuman.com": {
+        "/~backend/v3/sessions.getcsrftoken",
+        "/~backend/v3/sessions.gettokens",
+    },
+}
 
 
 class AttestationError(RuntimeError):
@@ -220,8 +224,10 @@ def _network_writes(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
         url = str(event.get("url") or "").lower()
         if method in {"GET", "HEAD", "OPTIONS"}:
             continue
-        action = urlparse(url).path.rstrip("/").rsplit("/", 1)[-1]
-        if method == "POST" and action in _READ_ONLY_POST_ACTIONS:
+        parsed = urlparse(url)
+        origin = f"{parsed.scheme}://{parsed.netloc}"
+        route = parsed.path.rstrip("/")
+        if method == "POST" and route in _READ_ONLY_POST_ROUTES.get(origin, set()):
             continue
         blocked.append({"method": method, "url": url})
     return blocked

--- a/superhuman_mail/cli.py
+++ b/superhuman_mail/cli.py
@@ -333,7 +333,9 @@ SCHEMA: dict[str, dict[str, Any]] = {
             "--confirm": {"required": False, "type": "flag", "hint": "Strict exact-attested send"},
             "--account": {"required": False, "type": "string"},
             "--attestation": {"required": False, "type": "string", "hint": "Required with --confirm"},
-            "--approval-ref": {"required": False, "type": "string", "hint": "Opaque approval reference; required with --confirm"},
+            "--approval-ref": {"required": False, "type": "string", "hint": "Audit correlation only (not authority); required with --confirm"},
+            "--cdp-url": {"required": False, "type": "string", "default": "http://127.0.0.1:9222"},
+            "--window-id": {"required": False, "type": "int"},
             "--delay": {"required": False, "type": "int", "default": 20},
             "--wait": {"required": False, "type": "float", "default": 120},
         },
@@ -712,7 +714,9 @@ def _build_parser() -> _ShmParser:
     send_g.add_argument("--confirm", action="store_true", help="Strict exact-attested send (irreversible)")
     send_p.add_argument("--account")
     send_p.add_argument("--attestation")
-    send_p.add_argument("--approval-ref")
+    send_p.add_argument("--approval-ref", help="Audit correlation only; does not grant send authority")
+    send_p.add_argument("--cdp-url", default="http://127.0.0.1:9222")
+    send_p.add_argument("--window-id", type=int)
     send_p.add_argument("--delay", type=int, default=20)
     send_p.add_argument("--wait", type=float, default=120)
 
@@ -752,6 +756,7 @@ def _typed_send_exit(data: dict[str, Any]) -> int:
         "send_requested",
         "send_pending_undo",
         "sent_backend_confirmed",
+        "inconsistent",
         "unknown",
     }:
         return 4
@@ -907,6 +912,7 @@ def main(argv: list[str] | None = None) -> int:
                 attestation=args.attestation,
                 approval_ref=args.approval_ref,
                 wait=args.wait,
+                renderer=_attestation.CdpRenderer(cdp_url=args.cdp_url, window_id=args.window_id),
             )
             if result["status"] == "succeeded":
                 return emit(result, exit_code=_typed_send_exit(result["data"]))

--- a/superhuman_mail/cli.py
+++ b/superhuman_mail/cli.py
@@ -745,6 +745,19 @@ def _build_parser() -> _ShmParser:
 # ---------------------------------------------------------------------------
 
 
+def _typed_send_exit(data: dict[str, Any]) -> int:
+    if data.get("sent") or data.get("state") == "scheduled":
+        return 0
+    if data.get("state") in {
+        "send_requested",
+        "send_pending_undo",
+        "sent_backend_confirmed",
+        "unknown",
+    }:
+        return 4
+    return 1
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     raw_argv = list(argv) if argv is not None else list(sys.argv[1:])
@@ -882,8 +895,8 @@ def main(argv: list[str] | None = None) -> int:
                 account=args.account,
                 wait=args.wait,
             )
-            if result["status"] == "succeeded" and not result["data"]["sent"] and result["data"]["state"] != "scheduled":
-                return emit(result, exit_code=4)
+            if result["status"] == "succeeded":
+                return emit(result, exit_code=_typed_send_exit(result["data"]))
             return emit(result)
         elif args.confirm:
             result = _send.execute(
@@ -895,8 +908,8 @@ def main(argv: list[str] | None = None) -> int:
                 approval_ref=args.approval_ref,
                 wait=args.wait,
             )
-            if result["status"] == "succeeded" and not result["data"]["sent"] and result["data"]["state"] != "scheduled":
-                return emit(result, exit_code=4)
+            if result["status"] == "succeeded":
+                return emit(result, exit_code=_typed_send_exit(result["data"]))
             return emit(result)
 
     # -- attestation --

--- a/superhuman_mail/cli.py
+++ b/superhuman_mail/cli.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any
 
 from . import _auth, _config, _local
+from . import approval as _approval
 from . import attestation as _attestation
 from . import comment as _comment
 from . import draft as _draft
@@ -30,7 +31,7 @@ from ._envelope import emit, error, fail, ok
 
 __version__ = "0.3.0"
 
-_COMMANDS = ["thread", "opens", "draft", "comment", "send", "attestation", "setup", "doctor", "schema"]
+_COMMANDS = ["thread", "opens", "draft", "comment", "send", "attestation", "approval", "setup", "doctor", "schema"]
 
 # ---------------------------------------------------------------------------
 # Schema definition (for agent introspection)
@@ -333,7 +334,8 @@ SCHEMA: dict[str, dict[str, Any]] = {
             "--confirm": {"required": False, "type": "flag", "hint": "Strict exact-attested send"},
             "--account": {"required": False, "type": "string"},
             "--attestation": {"required": False, "type": "string", "hint": "Required with --confirm"},
-            "--approval-ref": {"required": False, "type": "string", "hint": "Audit correlation only (not authority); required with --confirm"},
+            "--approval-receipt": {"required": False, "type": "string", "hint": "Externally signed exact-send receipt; required with --confirm"},
+            "--approval-ref": {"required": False, "type": "string", "hint": "Deprecated audit correlation; never authorizes"},
             "--cdp-url": {"required": False, "type": "string", "default": "http://127.0.0.1:9222"},
             "--window-id": {"required": False, "type": "int"},
             "--delay": {"required": False, "type": "int", "default": 20},
@@ -343,8 +345,17 @@ SCHEMA: dict[str, dict[str, Any]] = {
         "examples": [
             "shm send --dry-run THREAD DRAFT --account owner@example.com",
             "shm send status THREAD DRAFT --account owner@example.com --wait 120",
-            "shm send --confirm THREAD DRAFT --account owner@example.com --attestation ID --approval-ref REF --wait 120",
+            "shm send --confirm THREAD DRAFT --account owner@example.com --attestation ID --approval-receipt RECEIPT.json --wait 120",
         ],
+    },
+    "approval.verify": {
+        "description": "Verify an externally signed exact-send receipt and replay state",
+        "args": {
+            "reference": {"required": True, "type": "string"},
+            "--attestation": {"required": True, "type": "string"},
+        },
+        "safety": "read",
+        "examples": ["shm approval verify RECEIPT.json --attestation ID_OR_PATH"],
     },
     "attestation.show": {
         "description": "Verify and inspect a render attestation without exposing mail content",
@@ -714,7 +725,8 @@ def _build_parser() -> _ShmParser:
     send_g.add_argument("--confirm", action="store_true", help="Strict exact-attested send (irreversible)")
     send_p.add_argument("--account")
     send_p.add_argument("--attestation")
-    send_p.add_argument("--approval-ref", help="Audit correlation only; does not grant send authority")
+    send_p.add_argument("--approval-receipt", help="Externally signed exact-send approval receipt")
+    send_p.add_argument("--approval-ref", help="Deprecated audit correlation only; never grants authority")
     send_p.add_argument("--cdp-url", default="http://127.0.0.1:9222")
     send_p.add_argument("--window-id", type=int)
     send_p.add_argument("--delay", type=int, default=20)
@@ -728,6 +740,13 @@ def _build_parser() -> _ShmParser:
     a_show.add_argument("--account")
     a_show.add_argument("--thread-id")
     a_show.add_argument("--draft-id")
+
+    # -- approval (read-only external authority verification) --
+    approval_p = _sub(sub, "approval", help="Verify externally issued exact-send approval receipts")
+    apsub = approval_p.add_subparsers(dest="action")
+    ap_verify = _sub(apsub, "verify", help="Verify receipt authority/binding/replay state", schema_key="approval.verify")
+    ap_verify.add_argument("reference")
+    ap_verify.add_argument("--attestation", required=True)
 
     # -- setup --
     setup_p = _sub(sub, "setup", help="Auto-detect credentials from local Superhuman app", schema_key="setup")
@@ -910,6 +929,7 @@ def main(argv: list[str] | None = None) -> int:
                 delay=args.delay,
                 account=args.account,
                 attestation=args.attestation,
+                approval_receipt=args.approval_receipt,
                 approval_ref=args.approval_ref,
                 wait=args.wait,
                 renderer=_attestation.CdpRenderer(cdp_url=args.cdp_url, window_id=args.window_id),
@@ -933,6 +953,21 @@ def main(argv: list[str] | None = None) -> int:
                 return emit(ok("attestation.show", summary))
             except _attestation.AttestationError as exc:
                 return emit(fail("attestation.show", [error("conflict", exc.code, False, exc.hint)]))
+
+    # -- approval --
+    elif args.command == "approval":
+        if not hasattr(args, "action") or not args.action:
+            return emit(fail("approval", [error("input", "MISSING_ACTION", False, "Use: shm approval verify")]))
+        if args.action == "verify":
+            try:
+                return emit(ok(
+                    "approval.verify",
+                    _approval.show_safe(args.reference, attestation_reference=args.attestation),
+                ))
+            except _approval.ApprovalError as exc:
+                return emit(fail("approval.verify", [error("conflict", exc.code, False, exc.hint)]))
+            except _attestation.AttestationError as exc:
+                return emit(fail("approval.verify", [error("conflict", exc.code, False, exc.hint)]))
 
     # -- setup --
     elif args.command == "setup":

--- a/superhuman_mail/cli.py
+++ b/superhuman_mail/cli.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any
 
 from . import _auth, _config, _local
+from . import attestation as _attestation
 from . import comment as _comment
 from . import draft as _draft
 from . import opens as _opens
@@ -27,9 +28,9 @@ from . import share as _share
 from . import thread as _thread
 from ._envelope import emit, error, fail, ok
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"
 
-_COMMANDS = ["thread", "opens", "draft", "comment", "send", "setup", "doctor", "schema"]
+_COMMANDS = ["thread", "opens", "draft", "comment", "send", "attestation", "setup", "doctor", "schema"]
 
 # ---------------------------------------------------------------------------
 # Schema definition (for agent introspection)
@@ -46,7 +47,10 @@ SCHEMA: dict[str, dict[str, Any]] = {
     },
     "thread.userdata": {
         "description": "Advanced: raw thread userdata dump. Prefer draft read, comment read, or opens for specific data.",
-        "args": {"thread_id": {"required": True, "type": "string"}},
+        "args": {
+            "thread_id": {"required": True, "type": "string"},
+            "--account": {"required": False, "type": "string"},
+        },
         "safety": "read",
         "examples": [
             "shm thread userdata 19d001f35612a211",
@@ -201,16 +205,42 @@ SCHEMA: dict[str, dict[str, Any]] = {
         ],
     },
     "draft.read": {
-        "description": "Read draft(s) from a thread's userdata",
+        "description": "Read source drafts with canonical lifecycle and active/terminal counts",
         "args": {
             "thread_id": {"required": True, "type": "string"},
             "--draft-id": {"required": False, "type": "string"},
+            "--account": {"required": False, "type": "string"},
+            "--active-only": {"required": False, "type": "flag"},
         },
         "safety": "read",
         "examples": [
-            "shm draft read 19d001f35612a211",
+            "shm draft read 19d001f35612a211 --active-only",
             "shm draft read 19d001f35612a211 --draft-id draft00abc123",
         ],
+    },
+    "draft.status": {
+        "description": "Read canonical per-draft lifecycle/provenance",
+        "args": {
+            "thread_id": {"required": True, "type": "string"},
+            "--draft-id": {"required": False, "type": "string"},
+            "--account": {"required": False, "type": "string"},
+        },
+        "safety": "read",
+        "examples": ["shm draft status 19d001f35612a211 --draft-id draft00abc123 --account owner@example.com"],
+    },
+    "draft.attest-render": {
+        "description": "Create a signed exact live-Superhuman render attestation without mail writes",
+        "args": {
+            "thread_id": {"required": True, "type": "string"},
+            "draft_id": {"required": True, "type": "string"},
+            "--account": {"required": True, "type": "string"},
+            "--output": {"required": True, "type": "directory"},
+            "--cdp-url": {"required": False, "type": "string", "default": "http://127.0.0.1:9222"},
+            "--window-id": {"required": False, "type": "int", "hint": "macOS window ID fallback for screenshots"},
+            "--delay": {"required": False, "type": "int", "default": 20},
+        },
+        "safety": "read",
+        "examples": ["shm draft attest-render THREAD DRAFT --account owner@example.com --output ./preview"],
     },
     "draft.discard": {
         "description": "Discard (soft-delete) a draft",
@@ -294,19 +324,36 @@ SCHEMA: dict[str, dict[str, Any]] = {
         ],
     },
     "send": {
-        "description": "Send a draft — IRREVERSIBLE. Requires --dry-run or --confirm.",
+        "description": "Validate, reconcile, or strictly send an exactly attested draft",
         "args": {
             "thread_id": {"required": True, "type": "string"},
             "draft_id": {"required": True, "type": "string"},
-            "--dry-run": {"required": False, "type": "flag", "hint": "Validate without sending"},
-            "--confirm": {"required": False, "type": "flag", "hint": "Actually send (irreversible)"},
+            "--dry-run": {"required": False, "type": "flag", "hint": "Metadata/lifecycle preflight only"},
+            "--status": {"required": False, "type": "flag", "hint": "Reconcile without sending"},
+            "--confirm": {"required": False, "type": "flag", "hint": "Strict exact-attested send"},
+            "--account": {"required": False, "type": "string"},
+            "--attestation": {"required": False, "type": "string", "hint": "Required with --confirm"},
+            "--approval-ref": {"required": False, "type": "string", "hint": "Opaque approval reference; required with --confirm"},
             "--delay": {"required": False, "type": "int", "default": 20},
+            "--wait": {"required": False, "type": "float", "default": 120},
         },
         "safety": "irreversible",
         "examples": [
-            "shm send --dry-run 19d001f35612a211 draft00abc123",
-            "shm send --confirm 19d001f35612a211 draft00abc123",
+            "shm send --dry-run THREAD DRAFT --account owner@example.com",
+            "shm send status THREAD DRAFT --account owner@example.com --wait 120",
+            "shm send --confirm THREAD DRAFT --account owner@example.com --attestation ID --approval-ref REF --wait 120",
         ],
+    },
+    "attestation.show": {
+        "description": "Verify and inspect a render attestation without exposing mail content",
+        "args": {
+            "reference": {"required": True, "type": "string", "hint": "Attestation ID or local artifact path"},
+            "--account": {"required": False, "type": "string"},
+            "--thread-id": {"required": False, "type": "string"},
+            "--draft-id": {"required": False, "type": "string"},
+        },
+        "safety": "read",
+        "examples": ["shm attestation show ID --account owner@example.com --thread-id THREAD --draft-id DRAFT"],
     },
     "setup": {
         "description": "Auto-detect credentials from local Superhuman app and write config.json",
@@ -532,6 +579,7 @@ def _build_parser() -> _ShmParser:
 
     t_ud = _sub(tsub, "userdata", help="Read userdata from API (advanced)", schema_key="thread.userdata")
     t_ud.add_argument("thread_id")
+    t_ud.add_argument("--account")
 
     t_list = _sub(tsub, "list", help="List recent threads", schema_key="thread.list")
     t_list.add_argument("--limit", type=int, default=20)
@@ -599,9 +647,25 @@ def _build_parser() -> _ShmParser:
     d_compose.add_argument("--bcc", action="append", default=[])
     _add_smart_send_args(d_compose)
 
-    d_read = _sub(dsub, "read", help="Read draft(s)", schema_key="draft.read")
+    d_read = _sub(dsub, "read", help="Read draft(s) with lifecycle", schema_key="draft.read")
     d_read.add_argument("thread_id")
     d_read.add_argument("--draft-id")
+    d_read.add_argument("--account")
+    d_read.add_argument("--active-only", action="store_true")
+
+    d_status = _sub(dsub, "status", help="Read canonical draft lifecycle", schema_key="draft.status")
+    d_status.add_argument("thread_id")
+    d_status.add_argument("--draft-id")
+    d_status.add_argument("--account")
+
+    d_attest = _sub(dsub, "attest-render", help="Create exact live-render attestation", schema_key="draft.attest-render")
+    d_attest.add_argument("thread_id")
+    d_attest.add_argument("draft_id")
+    d_attest.add_argument("--account", required=True)
+    d_attest.add_argument("--output", required=True)
+    d_attest.add_argument("--cdp-url", default="http://127.0.0.1:9222")
+    d_attest.add_argument("--window-id", type=int)
+    d_attest.add_argument("--delay", type=int, default=20)
 
     d_discard = _sub(dsub, "discard", help="Discard a draft", schema_key="draft.discard")
     d_discard.add_argument("thread_id")
@@ -643,9 +707,23 @@ def _build_parser() -> _ShmParser:
     send_p.add_argument("thread_id")
     send_p.add_argument("draft_id")
     send_g = send_p.add_mutually_exclusive_group(required=True)
-    send_g.add_argument("--dry-run", action="store_true", help="Validate without sending")
-    send_g.add_argument("--confirm", action="store_true", help="Actually send (irreversible)")
+    send_g.add_argument("--dry-run", action="store_true", help="Metadata/lifecycle preflight without sending")
+    send_g.add_argument("--status", action="store_true", help="Reconcile status without sending")
+    send_g.add_argument("--confirm", action="store_true", help="Strict exact-attested send (irreversible)")
+    send_p.add_argument("--account")
+    send_p.add_argument("--attestation")
+    send_p.add_argument("--approval-ref")
     send_p.add_argument("--delay", type=int, default=20)
+    send_p.add_argument("--wait", type=float, default=120)
+
+    # -- attestation (read-only inspection) --
+    attestation_p = _sub(sub, "attestation", help="Inspect exact render attestations")
+    asub = attestation_p.add_subparsers(dest="action")
+    a_show = _sub(asub, "show", help="Verify and show safe attestation metadata", schema_key="attestation.show")
+    a_show.add_argument("reference")
+    a_show.add_argument("--account")
+    a_show.add_argument("--thread-id")
+    a_show.add_argument("--draft-id")
 
     # -- setup --
     setup_p = _sub(sub, "setup", help="Auto-detect credentials from local Superhuman app", schema_key="setup")
@@ -669,7 +747,12 @@ def _build_parser() -> _ShmParser:
 
 def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
-    args = parser.parse_args(argv)
+    raw_argv = list(argv) if argv is not None else list(sys.argv[1:])
+    # Additive spelling from the lifecycle design while retaining the existing
+    # flag-first ``shm send --dry-run THREAD DRAFT`` surface.
+    if len(raw_argv) >= 2 and raw_argv[:2] == ["send", "status"]:
+        raw_argv[1] = "--status"
+    args = parser.parse_args(raw_argv)
 
     if not args.command:
         return emit(fail("shm", [error("input", "NO_COMMAND", False,
@@ -682,7 +765,7 @@ def main(argv: list[str] | None = None) -> int:
         elif args.action == "messages":
             return emit(_thread.messages(args.thread_id))
         elif args.action == "userdata":
-            return emit(_thread.userdata(args.thread_id))
+            return emit(_thread.userdata(args.thread_id, account=args.account))
         elif args.action == "list":
             result = _thread.list_threads(limit=args.limit, unread=args.unread, include_participants=args.participants, account=args.account)
             if args.fail_empty and result["status"] == "succeeded" and result["data"]["returned"] == 0:
@@ -715,7 +798,7 @@ def main(argv: list[str] | None = None) -> int:
             "sensitivity_tenant_id": getattr(args, "sensitivity_tenant_id", None),
         }
         if not hasattr(args, "action") or not args.action:
-            return emit(fail("draft", [error("input", "MISSING_ACTION", False, "Use: shm draft reply|reply-all|forward|compose|read|discard|attach|share|unshare")]))
+            return emit(fail("draft", [error("input", "MISSING_ACTION", False, "Use: shm draft reply|reply-all|forward|compose|read|status|attest-render|discard|attach|share|unshare")]))
         elif args.action in ("reply", "reply-all", "forward", "compose"):
             schema_key = f"draft.{args.action}"
             try:
@@ -731,7 +814,40 @@ def main(argv: list[str] | None = None) -> int:
             elif args.action == "compose":
                 return emit(_draft.create_compose(args.subject, body, to=args.to, cc=args.cc, bcc=args.bcc, body_html=body_html, **ss))
         elif args.action == "read":
-            return emit(_draft.read(args.thread_id, draft_id=args.draft_id))
+            return emit(_draft.read(
+                args.thread_id,
+                draft_id=args.draft_id,
+                account=args.account,
+                active_only=args.active_only,
+            ))
+        elif args.action == "status":
+            return emit(_draft.status(args.thread_id, draft_id=args.draft_id, account=args.account))
+        elif args.action == "attest-render":
+            try:
+                record = _attestation.create(
+                    args.thread_id,
+                    args.draft_id,
+                    account=args.account,
+                    output_dir=Path(args.output),
+                    delay=args.delay,
+                    renderer=_attestation.CdpRenderer(cdp_url=args.cdp_url, window_id=args.window_id),
+                )
+                return emit(ok("draft.attest-render", {
+                    "attestation_id": record["attestation_id"],
+                    "artifact_path": record["artifact_path"],
+                    "created_at": record["created_at"],
+                    "expires_at": record["expires_at"],
+                    "send_eligible": record["send_eligible"],
+                    "confidence": record["confidence"],
+                    "account_email": record["account"]["email"],
+                    "thread_id": record["thread_id"],
+                    "draft_id": record["draft_id"],
+                    "fingerprint": record["fingerprint"]["exact"],
+                    "renderer": record["renderer"],
+                    "screenshots": record["screenshots"],
+                }))
+            except _attestation.AttestationError as exc:
+                return emit(fail("draft.attest-render", [error("conflict", exc.code, False, exc.hint)]))
         elif args.action == "discard":
             return emit(_draft.discard(args.thread_id, args.draft_id))
         elif args.action == "attach":
@@ -756,9 +872,48 @@ def main(argv: list[str] | None = None) -> int:
     # -- send --
     elif args.command == "send":
         if args.dry_run:
-            return emit(_send.validate(args.thread_id, args.draft_id))
+            return emit(_send.validate(args.thread_id, args.draft_id, account=args.account))
+        elif args.status:
+            if not args.account:
+                return emit(fail("send.status", [error("input", "ACCOUNT_REQUIRED", False, "--account is required")]))
+            result = _send.status(
+                args.thread_id,
+                args.draft_id,
+                account=args.account,
+                wait=args.wait,
+            )
+            if result["status"] == "succeeded" and not result["data"]["sent"] and result["data"]["state"] != "scheduled":
+                return emit(result, exit_code=4)
+            return emit(result)
         elif args.confirm:
-            return emit(_send.execute(args.thread_id, args.draft_id, delay=args.delay))
+            result = _send.execute(
+                args.thread_id,
+                args.draft_id,
+                delay=args.delay,
+                account=args.account,
+                attestation=args.attestation,
+                approval_ref=args.approval_ref,
+                wait=args.wait,
+            )
+            if result["status"] == "succeeded" and not result["data"]["sent"] and result["data"]["state"] != "scheduled":
+                return emit(result, exit_code=4)
+            return emit(result)
+
+    # -- attestation --
+    elif args.command == "attestation":
+        if not hasattr(args, "action") or not args.action:
+            return emit(fail("attestation", [error("input", "MISSING_ACTION", False, "Use: shm attestation show")]))
+        if args.action == "show":
+            try:
+                summary = _attestation.show_safe(
+                    args.reference,
+                    account=args.account,
+                    thread_id=args.thread_id,
+                    draft_id=args.draft_id,
+                )
+                return emit(ok("attestation.show", summary))
+            except _attestation.AttestationError as exc:
+                return emit(fail("attestation.show", [error("conflict", exc.code, False, exc.hint)]))
 
     # -- setup --
     elif args.command == "setup":

--- a/superhuman_mail/client.py
+++ b/superhuman_mail/client.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from . import approval as _approval
 from . import attestation as _attestation
 from . import comment as _comment
 from . import draft as _draft
@@ -139,6 +140,14 @@ class _SendOps:
         return _send.execute(thread_id, draft_id, **kwargs)
 
 
+class _ApprovalOps:
+    """External exact-send approval verification (read-only)."""
+
+    def verify(self, reference: str, *, attestation: str, **kwargs: Any) -> dict[str, Any]:
+        """Verify authority, exact binding, expiry, and replay state."""
+        return _approval.show_safe(reference, attestation_reference=attestation, **kwargs)
+
+
 class _ShareOps:
     """Backward-compatible share/unshare wrapper."""
 
@@ -168,4 +177,5 @@ class Client:
         self.draft = _DraftOps()
         self.comment = _CommentOps()
         self.send = _SendOps()
+        self.approval = _ApprovalOps()
         self.share = _ShareOps()

--- a/superhuman_mail/client.py
+++ b/superhuman_mail/client.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from . import attestation as _attestation
 from . import comment as _comment
 from . import draft as _draft
 from . import opens as _opens
@@ -33,9 +34,9 @@ class _ThreadOps:
         """Backward-compatible alias for messages()."""
         return self.messages(thread_id, account)
 
-    def userdata(self, thread_id: str) -> dict[str, Any]:
+    def userdata(self, thread_id: str, account: str | None = None) -> dict[str, Any]:
         """Read thread userdata from API."""
-        return _thread.userdata(thread_id)
+        return _thread.userdata(thread_id, account=account)
 
     def list(self, **kwargs: Any) -> dict[str, Any]:
         """List recent threads."""
@@ -77,9 +78,17 @@ class _DraftOps:
         """Create a new compose draft."""
         return _draft.create_compose(subject, body, **kwargs)
 
-    def read(self, thread_id: str, draft_id: str | None = None) -> dict[str, Any]:
-        """Read draft(s) from thread."""
-        return _draft.read(thread_id, draft_id)
+    def read(self, thread_id: str, draft_id: str | None = None, **kwargs: Any) -> dict[str, Any]:
+        """Read draft(s) with lifecycle metadata."""
+        return _draft.read(thread_id, draft_id, **kwargs)
+
+    def status(self, thread_id: str, draft_id: str | None = None, **kwargs: Any) -> dict[str, Any]:
+        """Read canonical draft/send lifecycle state."""
+        return _draft.status(thread_id, draft_id, **kwargs)
+
+    def attest_render(self, thread_id: str, draft_id: str, **kwargs: Any) -> dict[str, Any]:
+        """Create a signed exact live-Superhuman render attestation."""
+        return _attestation.create(thread_id, draft_id, **kwargs)
 
     def discard(self, thread_id: str, draft_id: str) -> dict[str, Any]:
         """Discard a draft."""
@@ -117,12 +126,16 @@ class _CommentOps:
 class _SendOps:
     """Send operations (irreversible)."""
 
-    def validate(self, thread_id: str, draft_id: str) -> dict[str, Any]:
-        """Dry-run: validate a draft is sendable."""
-        return _send.validate(thread_id, draft_id)
+    def validate(self, thread_id: str, draft_id: str, **kwargs: Any) -> dict[str, Any]:
+        """Dry-run: validate draft metadata and lifecycle."""
+        return _send.validate(thread_id, draft_id, **kwargs)
+
+    def status(self, thread_id: str, draft_id: str, **kwargs: Any) -> dict[str, Any]:
+        """Reconcile a send attempt without sending."""
+        return _send.status(thread_id, draft_id, **kwargs)
 
     def execute(self, thread_id: str, draft_id: str, **kwargs: Any) -> dict[str, Any]:
-        """Send a draft. IRREVERSIBLE."""
+        """Strict exact-attested send. IRREVERSIBLE."""
         return _send.execute(thread_id, draft_id, **kwargs)
 
 

--- a/superhuman_mail/draft.py
+++ b/superhuman_mail/draft.py
@@ -14,8 +14,8 @@ from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
 
-from . import _auth, _config, _local, thread as _thread
-from ._envelope import classify_exception, fail, ok
+from . import _auth, _config, _local, lifecycle, thread as _thread
+from ._envelope import classify_exception, error, fail, ok
 
 # ---------------------------------------------------------------------------
 # ID generation
@@ -733,22 +733,88 @@ def create_compose(
 # ---------------------------------------------------------------------------
 
 
-def read(thread_id: str, draft_id: str | None = None) -> dict[str, Any]:
-    """Read draft(s) from thread userdata."""
+def read(
+    thread_id: str,
+    draft_id: str | None = None,
+    *,
+    account: str | None = None,
+    active_only: bool = False,
+) -> dict[str, Any]:
+    """Read source drafts with explicit lifecycle and active/terminal counts."""
     try:
-        ud = _thread.userdata_raw(thread_id)
-        if not ud:
-            return ok("draft.read", {"thread_id": thread_id, "drafts": []})
-        msgs = ud.get("messages", {})
+        observed, warnings = lifecycle.observe_thread(thread_id, account=account)
+        msgs = observed["userdata"].get("messages", {})
+        states = observed["lifecycle_by_draft_id"]
         drafts: list[dict[str, Any]] = []
-        for mid, msg_data in msgs.items():
-            d = msg_data.get("draft")
-            if d and not msg_data.get("discardedAt"):
-                if draft_id is None or mid == draft_id:
-                    drafts.append(d)
-        return ok("draft.read", {"thread_id": thread_id, "draft_count": len(drafts), "drafts": drafts})
+        selected_states: dict[str, dict[str, Any]] = {}
+        active_count = 0
+        terminal_count = 0
+        nonterminal_blocked_count = 0
+
+        for mid, state in states.items():
+            if draft_id is not None and mid != draft_id:
+                continue
+            if state["state"] == lifecycle.ACTIVE:
+                active_count += 1
+            elif state["terminal"]:
+                terminal_count += 1
+            else:
+                nonterminal_blocked_count += 1
+            selected_states[mid] = state
+            if not active_only or state["state"] == lifecycle.ACTIVE:
+                draft_value = (msgs.get(mid) or {}).get("draft")
+                if isinstance(draft_value, dict):
+                    drafts.append(draft_value)
+
+        if terminal_count and not active_only:
+            warnings.append(
+                f"Included {terminal_count} terminal source draft(s); inspect lifecycle_by_draft_id before acting"
+            )
+        return ok("draft.read", {
+            "account": observed["account"],
+            "thread_id": thread_id,
+            "draft_count": len(drafts),
+            "active_draft_count": active_count,
+            "terminal_draft_count": terminal_count,
+            "nonterminal_blocked_draft_count": nonterminal_blocked_count,
+            "active_only": active_only,
+            "drafts": drafts,
+            "lifecycle_by_draft_id": selected_states,
+        }, warnings=warnings)
+    except LookupError:
+        return ok("draft.read", {
+            "thread_id": thread_id,
+            "draft_count": 0,
+            "active_draft_count": 0,
+            "terminal_draft_count": 0,
+            "nonterminal_blocked_draft_count": 0,
+            "active_only": active_only,
+            "drafts": [],
+            "lifecycle_by_draft_id": {},
+        })
     except Exception as e:
         return fail("draft.read", [classify_exception(e)])
+
+
+def status(thread_id: str, draft_id: str | None = None, *, account: str | None = None) -> dict[str, Any]:
+    """Return canonical lifecycle state without presenting source drafts as mail."""
+    try:
+        observed, warnings = lifecycle.observe_thread(thread_id, account=account)
+        states = observed["lifecycle_by_draft_id"]
+        if draft_id is not None:
+            state = states.get(draft_id)
+            if state is None:
+                return fail("draft.status", [
+                    error("not-found", "DRAFT_NOT_FOUND", False, f"Draft {draft_id} not found on thread {thread_id}")
+                ])
+            states = {draft_id: state}
+        return ok("draft.status", {
+            "account": observed["account"],
+            "thread_id": thread_id,
+            "lifecycle_by_draft_id": states,
+        }, warnings=warnings)
+    except Exception as e:
+        return fail("draft.status", [classify_exception(e)])
 
 
 def discard(thread_id: str, draft_id: str) -> dict[str, Any]:

--- a/superhuman_mail/lifecycle.py
+++ b/superhuman_mail/lifecycle.py
@@ -1,0 +1,411 @@
+"""Canonical Superhuman draft/send lifecycle classification.
+
+A source draft is not outbound evidence.  This module joins the message-level
+userdata wrapper (including ``sendJob``) with immutable provider messages from
+Superhuman's local cache and returns an explicit, provenance-bearing state.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+from . import _config, _local, thread as _thread
+
+ACTIVE = "active_draft"
+SCHEDULED = "scheduled"
+REQUESTED = "send_requested"
+PENDING_UNDO = "send_pending_undo"
+FAILED = "send_failed"
+ABORTED = "send_aborted"
+DISCARDED = "discarded"
+BACKEND_CONFIRMED = "sent_backend_confirmed"
+PROVIDER_CONFIRMED = "sent_provider_confirmed"
+INCONSISTENT = "inconsistent"
+
+TERMINAL_STATES = {
+    FAILED,
+    ABORTED,
+    DISCARDED,
+    BACKEND_CONFIRMED,
+    PROVIDER_CONFIRMED,
+    INCONSISTENT,
+}
+BLOCKING_STATES = TERMINAL_STATES | {SCHEDULED, REQUESTED, PENDING_UNDO}
+
+
+class AccountBindingError(ValueError):
+    """The requested mailbox cannot be bound to the configured API identity."""
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def _parse_time(value: Any) -> datetime | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, (int, float)):
+        # Superhuman timestamps are normally epoch milliseconds.
+        seconds = float(value) / 1000 if abs(float(value)) > 10_000_000_000 else float(value)
+        try:
+            return datetime.fromtimestamp(seconds, timezone.utc)
+        except (OSError, OverflowError, ValueError):
+            return None
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+        except ValueError:
+            return None
+    return None
+
+
+def _iso(value: Any) -> str | None:
+    parsed = _parse_time(value)
+    return parsed.astimezone(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z") if parsed else None
+
+
+def resolve_account(account: str | None = None, *, require_explicit: bool = False) -> tuple[dict[str, str], list[str]]:
+    """Resolve a mailbox to the immutable API user identity.
+
+    The current private API credentials are bound to one Google/provider user.
+    Local DB discovery can list additional mailboxes, but combining one of those
+    DBs with the configured userdata credential would be unsafe.  Fail rather
+    than guess.
+    """
+    cfg = _config.load()
+    api_cfg = cfg.get("superhuman_api", {})
+    configured_email = str(api_cfg.get("email") or cfg.get("email_account") or "").strip()
+    provider_user_id = str(api_cfg.get("google_id") or "").strip()
+    if not configured_email or not provider_user_id:
+        raise AccountBindingError("Configured Superhuman account is missing email or immutable provider user ID")
+
+    accounts = [str(item.get("email", "")).strip() for item in cfg.get("superhuman", {}).get("accounts", [])]
+    accounts = [item for item in accounts if item]
+    warnings: list[str] = []
+
+    if account is None:
+        if require_explicit and len({item.lower() for item in accounts}) > 1:
+            raise AccountBindingError("Multiple Superhuman accounts are configured; --account is required")
+        account = configured_email
+        if require_explicit:
+            warnings.append(f"No --account supplied; bound to configured account {configured_email}")
+
+    if account.strip().lower() != configured_email.lower():
+        raise AccountBindingError(
+            f"Account {account} is not bound to the configured API identity {configured_email}; run setup for that account"
+        )
+
+    return {"email": configured_email, "provider_user_id": provider_user_id}, warnings
+
+
+def _field(obj: dict[str, Any] | None, *names: str) -> Any:
+    source = obj or {}
+    for name in names:
+        if name in source and source[name] not in (None, ""):
+            return source[name]
+    return None
+
+
+def _labels(message: dict[str, Any]) -> set[str]:
+    return {str(item).upper() for item in (message.get("labelIds") or message.get("labels") or [])}
+
+
+def _sender_email(message: dict[str, Any]) -> str:
+    sender = message.get("from") or message.get("sender") or {}
+    if isinstance(sender, dict):
+        return str(sender.get("email") or sender.get("emailAddress") or "").strip().lower()
+    return str(sender).strip().lower()
+
+
+def _message_id(message: dict[str, Any]) -> str:
+    return str(message.get("id") or message.get("messageId") or "")
+
+
+def _provider_draft_id(message: dict[str, Any]) -> str | None:
+    value = _field(message, "superhumanOwnDraftId", "superhumanDraftId", "superhuman_own_draft_id")
+    return str(value) if value is not None else None
+
+
+def _provider_superhuman_id(message: dict[str, Any]) -> str | None:
+    value = _field(message, "superhumanId", "superhuman_id")
+    return str(value) if value is not None else None
+
+
+def _provider_proof(
+    messages: Iterable[dict[str, Any]],
+    *,
+    account_email: str,
+    draft_id: str,
+    send_job: dict[str, Any],
+    attempt_superhuman_id: str | None,
+) -> tuple[dict[str, Any] | None, bool]:
+    """Return an unambiguously linked SENT provider message and conflict flag."""
+    job_message_id = str(_field(send_job, "messageId", "message_id") or "")
+    expected_sid = str(_field(send_job, "superhumanId", "superhuman_id") or attempt_superhuman_id or "")
+    conflict = False
+
+    for message in messages:
+        if "SENT" not in _labels(message) or _sender_email(message) != account_email.lower():
+            continue
+        mid = _message_id(message)
+        linked_draft = _provider_draft_id(message)
+        linked_sid = _provider_superhuman_id(message)
+
+        # Proof A: exact immutable provider ID from the completed backend job.
+        if job_message_id and mid == job_message_id:
+            if linked_draft is not None and linked_draft != draft_id:
+                conflict = True
+                continue
+            if linked_sid is not None and expected_sid and linked_sid != expected_sid:
+                conflict = True
+                continue
+            return message, conflict
+
+        # Proof B: userdata may lag, but both source-draft and attempt identities link.
+        if linked_draft == draft_id and expected_sid and linked_sid == expected_sid:
+            return message, conflict
+
+        # A message that claims either identity but disagrees on the other is evidence
+        # of contradictory linkage, not a fuzzy match.
+        if linked_draft == draft_id or (expected_sid and linked_sid == expected_sid) or (job_message_id and mid == job_message_id):
+            conflict = True
+
+    return None, conflict
+
+
+def _has_failure(job: dict[str, Any]) -> bool:
+    return any(bool(_field(job, name)) for name in ("failedAt", "failureAt", "error", "failureReason"))
+
+
+def _has_abort(job: dict[str, Any]) -> bool:
+    return any(
+        bool(_field(job, name))
+        for name in ("abortedAt", "abortAt", "cancelledAt", "canceledAt", "unscheduledAt")
+    )
+
+
+def _replacement_thread_id(userdata: dict[str, Any], wrapper: dict[str, Any]) -> str | None:
+    candidates = [userdata.get("threadReplacement"), wrapper.get("threadReplacement")]
+    for item in candidates:
+        if isinstance(item, str) and item:
+            return item
+        if isinstance(item, dict):
+            value = _field(item, "movedToThreadId", "threadId", "replacementThreadId")
+            if value:
+                return str(value)
+    job = wrapper.get("sendJob") or {}
+    value = _field(job, "threadId", "thread_id")
+    return str(value) if value else None
+
+
+def classify(
+    *,
+    account: dict[str, str],
+    thread_id: str,
+    draft_id: str,
+    userdata: dict[str, Any],
+    provider_messages: Iterable[dict[str, Any]] = (),
+    observed_at: str | None = None,
+    attempt_superhuman_id: str | None = None,
+    provider_thread_id: str | None = None,
+) -> dict[str, Any]:
+    """Classify one ``(account, thread, draft)`` from already-read evidence."""
+    observed_at = observed_at or _now_iso()
+    wrapper = (userdata.get("messages") or {}).get(draft_id) or {}
+    draft = wrapper.get("draft") or {}
+    job = wrapper.get("sendJob") or {}
+    provider_messages = list(provider_messages)
+
+    provider, linkage_conflict = _provider_proof(
+        provider_messages,
+        account_email=account["email"],
+        draft_id=draft_id,
+        send_job=job,
+        attempt_superhuman_id=attempt_superhuman_id,
+    )
+    has_failure = _has_failure(job)
+    has_abort = _has_abort(job)
+    backend_success = bool(_field(job, "sentAt") and _field(job, "messageId", "message_id"))
+    contradictory = sum(bool(item) for item in (backend_success, has_failure, has_abort)) > 1 or linkage_conflict
+    consistency = "conflicting" if contradictory or (provider is not None and (has_failure or has_abort)) else "matched"
+
+    if provider is not None:
+        state = PROVIDER_CONFIRMED
+        confidence = "provider_confirmed"
+        outbound = True
+    elif contradictory:
+        state = INCONSISTENT
+        confidence = "conflicting"
+        outbound = False
+    elif backend_success:
+        state = BACKEND_CONFIRMED
+        confidence = "backend_confirmed"
+        outbound = False
+    elif has_failure:
+        state = FAILED
+        confidence = "backend_terminal"
+        outbound = False
+    elif has_abort:
+        state = ABORTED
+        confidence = "backend_terminal"
+        outbound = False
+    elif job:
+        send_at = _parse_time(_field(job, "sendAt", "send_at"))
+        scheduled_for = _parse_time(_field(draft, "scheduledFor", "scheduled_for"))
+        if scheduled_for and send_at and send_at > datetime.now(timezone.utc):
+            state = SCHEDULED
+        elif bool(_field(job, "notSentToServer", "not_sent_to_server")):
+            state = REQUESTED
+        elif send_at and send_at > datetime.now(timezone.utc):
+            state = PENDING_UNDO
+        else:
+            state = REQUESTED
+        confidence = "backend_nonterminal"
+        outbound = False
+    elif wrapper.get("discardedAt") or draft.get("discardedAt"):
+        state = DISCARDED
+        confidence = "userdata"
+        outbound = False
+    else:
+        state = ACTIVE
+        confidence = "userdata"
+        outbound = False
+
+    provider_data: dict[str, Any] | None = None
+    if provider is not None:
+        provider_data = {
+            "id": _message_id(provider),
+            "thread_id": provider_thread_id or thread_id,
+            "labels": sorted(_labels(provider)),
+            "superhuman_own_draft_id": _provider_draft_id(provider),
+            "superhuman_id": _provider_superhuman_id(provider),
+            "date": _iso(provider.get("date")),
+        }
+
+    return {
+        "account": dict(account),
+        "thread_id": thread_id,
+        "draft_id": draft_id,
+        "state": state,
+        "terminal": state in TERMINAL_STATES,
+        "send_blocked": state in BLOCKING_STATES,
+        "outbound_evidence": outbound,
+        "confidence": confidence,
+        "consistency": consistency,
+        "timestamps": {
+            "draft_created_at": _iso(_field(draft, "clientCreatedAt", "date")),
+            "scheduled_for": _iso(_field(draft, "scheduledFor", "scheduled_for")),
+            "send_at": _iso(_field(job, "sendAt", "send_at")),
+            "sent_at": _iso(_field(job, "sentAt", "sent_at")),
+            "send_verified_at": _iso(_field(job, "sendVerifiedAt", "send_verified_at")),
+            "failed_at": _iso(_field(job, "failedAt", "failureAt")),
+            "aborted_at": _iso(_field(job, "abortedAt", "cancelledAt", "canceledAt")),
+            "provider_message_at": _iso(provider.get("date")) if provider else None,
+        },
+        "send_job": {
+            "message_id": _field(job, "messageId", "message_id"),
+            "superhuman_id": _field(job, "superhumanId", "superhuman_id"),
+            "not_sent_to_server": bool(_field(job, "notSentToServer", "not_sent_to_server")),
+            "present": bool(job),
+        },
+        "provider_message": provider_data,
+        "observations": [
+            {
+                "source": "superhuman_userdata_api",
+                "history_id": userdata.get("historyId"),
+                "observed_at": observed_at,
+            },
+            {
+                "source": "superhuman_local_cache",
+                "provider_thread_id": provider_thread_id or thread_id,
+                "message_count": len(provider_messages),
+                "observed_at": observed_at,
+            },
+        ],
+    }
+
+
+def observe_thread(
+    thread_id: str,
+    *,
+    account: str | None = None,
+    require_explicit_account: bool = False,
+    attempt_ids: dict[str, str] | None = None,
+) -> tuple[dict[str, Any], list[str]]:
+    """Read userdata/cache once and classify every source draft on a thread."""
+    identity, warnings = resolve_account(account, require_explicit=require_explicit_account)
+    userdata = _thread.userdata_raw(thread_id, account=identity["email"])
+    if not userdata:
+        raise LookupError(f"No userdata for thread {thread_id}")
+
+    provider_thread_id = thread_id
+    provider_messages: list[dict[str, Any]] = []
+    try:
+        raw = _local.get_thread_json(thread_id, identity["email"])
+        provider_messages.extend(list(raw.get("messages") or []))
+    except Exception as exc:
+        warnings.append(f"Provider cache unavailable for {thread_id}: {exc}")
+
+    # Synthetic compose threads may be replaced with the immutable provider thread.
+    for wrapper in (userdata.get("messages") or {}).values():
+        replacement = _replacement_thread_id(userdata, wrapper or {})
+        if replacement and replacement != thread_id:
+            provider_thread_id = replacement
+            try:
+                raw = _local.get_thread_json(replacement, identity["email"])
+                provider_messages.extend(list(raw.get("messages") or []))
+            except Exception as exc:
+                warnings.append(f"Replacement provider cache unavailable for {replacement}: {exc}")
+            break
+
+    observed_at = _now_iso()
+    lifecycle_by_id: dict[str, dict[str, Any]] = {}
+    for draft_id, wrapper in (userdata.get("messages") or {}).items():
+        if not isinstance(wrapper, dict) or not (
+            wrapper.get("draft") or wrapper.get("sendJob") or wrapper.get("discardedAt")
+        ):
+            continue
+        lifecycle_by_id[str(draft_id)] = classify(
+            account=identity,
+            thread_id=thread_id,
+            draft_id=str(draft_id),
+            userdata=userdata,
+            provider_messages=provider_messages,
+            observed_at=observed_at,
+            attempt_superhuman_id=(attempt_ids or {}).get(str(draft_id)),
+            provider_thread_id=provider_thread_id,
+        )
+
+    return {
+        "account": identity,
+        "thread_id": thread_id,
+        "userdata": userdata,
+        "provider_thread_id": provider_thread_id,
+        "lifecycle_by_draft_id": lifecycle_by_id,
+        "observed_at": observed_at,
+    }, warnings
+
+
+def observe(
+    thread_id: str,
+    draft_id: str,
+    *,
+    account: str | None = None,
+    require_explicit_account: bool = False,
+    attempt_superhuman_id: str | None = None,
+) -> tuple[dict[str, Any], dict[str, Any], list[str]]:
+    """Read and classify one draft, returning lifecycle, raw wrapper, warnings."""
+    observed, warnings = observe_thread(
+        thread_id,
+        account=account,
+        require_explicit_account=require_explicit_account,
+        attempt_ids={draft_id: attempt_superhuman_id} if attempt_superhuman_id else None,
+    )
+    lifecycle = observed["lifecycle_by_draft_id"].get(draft_id)
+    if lifecycle is None:
+        raise LookupError(f"Draft {draft_id} not found on thread {thread_id}")
+    wrapper = (observed["userdata"].get("messages") or {}).get(draft_id) or {}
+    return lifecycle, wrapper, warnings

--- a/superhuman_mail/lifecycle.py
+++ b/superhuman_mail/lifecycle.py
@@ -179,6 +179,10 @@ def _provider_proof(
     return candidate, conflict
 
 
+def _has_any_field(job: dict[str, Any], *names: str) -> bool:
+    return any(name in job for name in names)
+
+
 def _has_failure(job: dict[str, Any]) -> bool:
     return any(bool(_field(job, name)) for name in ("failedAt", "failureAt", "error", "failureReason"))
 
@@ -324,6 +328,7 @@ def classify(
             "message_id": _field(job, "messageId", "message_id"),
             "superhuman_id": _field(job, "superhumanId", "superhuman_id"),
             "not_sent_to_server": bool(_field(job, "notSentToServer", "not_sent_to_server")),
+            "not_sent_to_server_present": _has_any_field(job, "notSentToServer", "not_sent_to_server"),
             "present": bool(job),
             "sending": bool(wrapper.get("sending")),
         },

--- a/superhuman_mail/lifecycle.py
+++ b/superhuman_mail/lifecycle.py
@@ -146,6 +146,7 @@ def _provider_proof(
     job_message_id = str(_field(send_job, "messageId", "message_id") or "")
     expected_sid = str(_field(send_job, "superhumanId", "superhuman_id") or attempt_superhuman_id or "")
     conflict = False
+    candidate: dict[str, Any] | None = None
 
     for message in messages:
         if "SENT" not in _labels(message) or _sender_email(message) != account_email.lower():
@@ -162,18 +163,20 @@ def _provider_proof(
             if linked_sid is not None and expected_sid and linked_sid != expected_sid:
                 conflict = True
                 continue
-            return message, conflict
+            candidate = candidate or message
+            continue
 
         # Proof B: userdata may lag, but both source-draft and attempt identities link.
         if linked_draft == draft_id and expected_sid and linked_sid == expected_sid:
-            return message, conflict
+            candidate = candidate or message
+            continue
 
         # A message that claims either identity but disagrees on the other is evidence
         # of contradictory linkage, not a fuzzy match.
         if linked_draft == draft_id or (expected_sid and linked_sid == expected_sid) or (job_message_id and mid == job_message_id):
             conflict = True
 
-    return None, conflict
+    return candidate, conflict
 
 
 def _has_failure(job: dict[str, Any]) -> bool:
@@ -271,6 +274,12 @@ def classify(
             state = REQUESTED
         confidence = "backend_nonterminal"
         outbound = False
+    elif wrapper.get("sending"):
+        # Superhuman sets this optimistic wrapper flag before sendJob is fully
+        # materialized. Treat it as blocking native-send evidence.
+        state = REQUESTED
+        confidence = "userdata_optimistic"
+        outbound = False
     elif wrapper.get("discardedAt") or draft.get("discardedAt"):
         state = DISCARDED
         confidence = "userdata"
@@ -316,6 +325,7 @@ def classify(
             "superhuman_id": _field(job, "superhumanId", "superhuman_id"),
             "not_sent_to_server": bool(_field(job, "notSentToServer", "not_sent_to_server")),
             "present": bool(job),
+            "sending": bool(wrapper.get("sending")),
         },
         "provider_message": provider_data,
         "observations": [

--- a/superhuman_mail/lifecycle.py
+++ b/superhuman_mail/lifecycle.py
@@ -228,8 +228,14 @@ def classify(
     )
     has_failure = _has_failure(job)
     has_abort = _has_abort(job)
-    backend_success = bool(_field(job, "sentAt") and _field(job, "messageId", "message_id"))
-    contradictory = sum(bool(item) for item in (backend_success, has_failure, has_abort)) > 1 or linkage_conflict
+    sent_at_present = bool(_field(job, "sentAt"))
+    backend_success = bool(sent_at_present and _field(job, "messageId", "message_id"))
+    partial_terminal_success = (sent_at_present or bool(_field(job, "sendVerifiedAt", "send_verified_at"))) and not backend_success
+    contradictory = (
+        sum(bool(item) for item in (backend_success, has_failure, has_abort)) > 1
+        or linkage_conflict
+        or partial_terminal_success
+    )
     consistency = "conflicting" if contradictory or (provider is not None and (has_failure or has_abort)) else "matched"
 
     if provider is not None:
@@ -255,10 +261,10 @@ def classify(
     elif job:
         send_at = _parse_time(_field(job, "sendAt", "send_at"))
         scheduled_for = _parse_time(_field(draft, "scheduledFor", "scheduled_for"))
-        if scheduled_for and send_at and send_at > datetime.now(timezone.utc):
-            state = SCHEDULED
-        elif bool(_field(job, "notSentToServer", "not_sent_to_server")):
+        if bool(_field(job, "notSentToServer", "not_sent_to_server")):
             state = REQUESTED
+        elif scheduled_for and send_at and send_at > datetime.now(timezone.utc):
+            state = SCHEDULED
         elif send_at and send_at > datetime.now(timezone.utc):
             state = PENDING_UNDO
         else:

--- a/superhuman_mail/renderer_probe.js
+++ b/superhuman_mail/renderer_probe.js
@@ -356,7 +356,6 @@ async function main() {
   const targetsResponse = await fetch(`${cdpBase}/json/list`);
   if (!targetsResponse.ok) throw new Error(`CDP discovery failed: HTTP ${targetsResponse.status}`);
   const targets = await targetsResponse.json();
-  const exactThreadPath = `/thread/${input.thread_id}`;
   const candidates = targets.filter(item =>
     item.type === "page" &&
     String(item.url || "").startsWith("https://mail.superhuman.com/") &&
@@ -364,7 +363,6 @@ async function main() {
     item.webSocketDebuggerUrl
   );
   let target = null;
-  let firstModelTarget = null;
   const modelCheck = `(() => {
     const wanted = ${JSON.stringify(input.draft_id)};
     const seen = new WeakSet();
@@ -392,7 +390,6 @@ async function main() {
         returnByValue: true,
       });
       const value = JSON.parse(checked.result && checked.result.value || "{}");
-      if (value.hasModel && !firstModelTarget) firstModelTarget = candidate;
       if (value.hasModel && value.visible) {
         target = candidate;
         break;
@@ -403,8 +400,9 @@ async function main() {
       inspector.close();
     }
   }
-  target = target || firstModelTarget || candidates.find(item => String(item.url || "").includes(exactThreadPath));
-  if (!target) throw new Error("No visible Superhuman page target found on the CDP endpoint");
+  if (!target) {
+    throw new Error(`DRAFT_MODEL_NOT_FOUND: exact draft ${input.draft_id} must already be visible; probe will not focus or navigate`);
+  }
   if (process.env.SHM_RENDERER_DEBUG) process.stderr.write(`probe:target ${target.id} ${target.url}\n`);
 
   const client = new CDP(target.webSocketDebuggerUrl);
@@ -424,10 +422,9 @@ async function main() {
     networkOffline = true;
     client.events = [];
     client.interceptions = [];
-    // Fetch interception is active before focus/render work so an autosave or
-    // other non-idempotent request is aborted before any bytes are dispatched.
-    await client.send("Page.bringToFront");
-
+    // The probe never focuses/navigates. Fetch interception and offline mode
+    // are active before render work so an autosave or other non-idempotent
+    // request is aborted before any bytes are dispatched.
     const renderExpression = expressionFor(input);
     if (process.env.SHM_RENDERER_DEBUG_EXPRESSION) {
       fs.writeFileSync(process.env.SHM_RENDERER_DEBUG_EXPRESSION, renderExpression);

--- a/superhuman_mail/renderer_probe.js
+++ b/superhuman_mail/renderer_probe.js
@@ -17,6 +17,23 @@ function arg(name, fallback) {
   return index >= 0 && process.argv[index + 1] ? process.argv[index + 1] : fallback;
 }
 
+const READ_ONLY_POST_ACTIONS = [
+  "userdata.getthreads", "userdata.read", "userdata.searchhistory", "userdata.sync",
+  "autolabels.preview", "labels.recentchanges", "labels.resync",
+  "autodrafts.previeweascheduling", "smartsend.gettimerange",
+  "sessions.getcsrftoken", "sessions.gettokens", "teams.caninvite", "teams.classify",
+  "teams.getbillingfeaturesbysku", "teams.members", "teams.suggest", "links.content",
+  "translate.detectlanguage", "users.getreferral", "users.refreshaliases",
+];
+
+function requestDisposition(methodValue, urlValue) {
+  const method = String(methodValue || "GET").toUpperCase();
+  if (["GET", "HEAD", "OPTIONS"].includes(method)) return "continue";
+  let action = "";
+  try { action = new URL(String(urlValue || "")).pathname.replace(/\/$/, "").split("/").pop().toLowerCase(); } catch (_) {}
+  return method === "POST" && READ_ONLY_POST_ACTIONS.includes(action) ? "continue" : "fail";
+}
+
 const RENDERER_CONTRACT = {
   adapter_version: "superhuman-cdp-v1",
   outgoing_fields: [
@@ -27,9 +44,21 @@ const RENDERER_CONTRACT = {
   ],
   reminder: "persisted_draft_only_current_build",
   mutates_mail_state: false,
+  blocks_non_idempotent_before_dispatch: true,
+  network_offline_during_render: true,
+  read_only_post_actions: READ_ONLY_POST_ACTIONS,
 };
 if (process.argv.includes("--print-contract")) {
   process.stdout.write(JSON.stringify(RENDERER_CONTRACT));
+  process.exit(0);
+}
+if (process.argv.includes("--test-network-policy")) {
+  const requests = JSON.parse(fs.readFileSync(0, "utf8"));
+  process.stdout.write(JSON.stringify(requests.map(item => ({
+    method: item.method,
+    url: item.url,
+    disposition: requestDisposition(item.method, item.url),
+  }))));
   process.exit(0);
 }
 
@@ -46,6 +75,7 @@ class CDP {
     this.sequence = 0;
     this.pending = new Map();
     this.events = [];
+    this.interceptions = [];
   }
 
   async connect() {
@@ -66,6 +96,19 @@ class CDP {
       } else if (message.method === "Network.requestWillBeSent") {
         const request = message.params && message.params.request || {};
         this.events.push({ method: request.method || "GET", url: request.url || "" });
+      } else if (message.method === "Fetch.requestPaused") {
+        const params = message.params || {};
+        const request = params.request || {};
+        const method = request.method || "GET";
+        const url = request.url || "";
+        const disposition = requestDisposition(method, url);
+        this.events.push({ method, url, blocked: disposition === "fail" });
+        const intercepted = disposition === "continue"
+          ? this.send("Fetch.continueRequest", { requestId: params.requestId }, 5000)
+          : this.send("Fetch.failRequest", { requestId: params.requestId, errorReason: "BlockedByClient" }, 5000);
+        this.interceptions.push(intercepted.catch(error => {
+          throw new Error(`FETCH_INTERCEPTION_FAILED: ${error.message}`);
+        }));
       }
     });
   }
@@ -365,12 +408,24 @@ async function main() {
   if (process.env.SHM_RENDERER_DEBUG) process.stderr.write(`probe:target ${target.id} ${target.url}\n`);
 
   const client = new CDP(target.webSocketDebuggerUrl);
+  let networkOffline = false;
   await client.connect();
   try {
     await client.send("Runtime.enable");
     await client.send("Network.enable");
     await client.send("Page.enable");
+    await client.send("Fetch.enable", { patterns: [{ urlPattern: "*", requestStage: "Request" }] });
+    await client.send("Network.emulateNetworkConditions", {
+      offline: true,
+      latency: 0,
+      downloadThroughput: 0,
+      uploadThroughput: 0,
+    });
+    networkOffline = true;
     client.events = [];
+    client.interceptions = [];
+    // Fetch interception is active before focus/render work so an autosave or
+    // other non-idempotent request is aborted before any bytes are dispatched.
     await client.send("Page.bringToFront");
 
     const renderExpression = expressionFor(input);
@@ -434,11 +489,34 @@ async function main() {
     await capture(outgoingPath, { x: rect.x, y: rect.y, width: rect.width, height: rect.height, scale: 1 });
     if (process.env.SHM_RENDERER_DEBUG) process.stderr.write("probe:outgoing-shot\n");
     await evaluate(client, `(() => { const node = document.getElementById("__shm_attestation_overlay"); if (node) node.remove(); return true; })()`);
+    await client.send("Network.emulateNetworkConditions", {
+      offline: false,
+      latency: 0,
+      downloadThroughput: -1,
+      uploadThroughput: -1,
+    });
+    networkOffline = false;
+    // Keep interception active while the app observes connectivity restoration;
+    // any queued mutation is still failed before dispatch.
+    await new Promise(resolve => setTimeout(resolve, 100));
+    await Promise.all(client.interceptions);
+    await client.send("Fetch.disable");
 
     result.network_events = client.events;
     result.screenshots = [composePath, outgoingPath];
     process.stdout.write(JSON.stringify(result));
   } finally {
+    if (networkOffline) {
+      try {
+        await client.send("Network.emulateNetworkConditions", {
+          offline: false,
+          latency: 0,
+          downloadThroughput: -1,
+          uploadThroughput: -1,
+        }, 1000);
+      } catch (_) {}
+    }
+    try { await client.send("Fetch.disable", {}, 1000); } catch (_) {}
     client.close();
   }
 }

--- a/superhuman_mail/renderer_probe.js
+++ b/superhuman_mail/renderer_probe.js
@@ -17,21 +17,33 @@ function arg(name, fallback) {
   return index >= 0 && process.argv[index + 1] ? process.argv[index + 1] : fallback;
 }
 
-const READ_ONLY_POST_ACTIONS = [
-  "userdata.getthreads", "userdata.read", "userdata.searchhistory", "userdata.sync",
-  "autolabels.preview", "labels.recentchanges", "labels.resync",
-  "autodrafts.previeweascheduling", "smartsend.gettimerange",
-  "sessions.getcsrftoken", "sessions.gettokens", "teams.caninvite", "teams.classify",
-  "teams.getbillingfeaturesbysku", "teams.members", "teams.suggest", "links.content",
-  "translate.detectlanguage", "users.getreferral", "users.refreshaliases",
-];
+const READ_ONLY_POST_ROUTES = {
+  "https://mail.superhuman.com": [
+    "/~backend/v3/userdata.getthreads", "/~backend/v3/userdata.read",
+    "/~backend/v3/userdata.searchhistory", "/~backend/v3/userdata.sync",
+    "/~backend/v3/autolabels.preview", "/~backend/v3/labels.recentchanges",
+    "/~backend/v3/labels.resync", "/~backend/v3/autodrafts.previeweascheduling",
+    "/~backend/v3/smartsend.gettimerange", "/~backend/v3/teams.caninvite",
+    "/~backend/v3/teams.classify", "/~backend/v3/teams.getbillingfeaturesbysku",
+    "/~backend/v3/teams.members", "/~backend/v3/teams.suggest",
+    "/~backend/v3/links.content", "/~backend/v3/translate.detectlanguage",
+    "/~backend/v3/users.getreferral", "/~backend/v3/users.refreshaliases",
+  ],
+  "https://accounts.superhuman.com": [
+    "/~backend/v3/sessions.getcsrftoken", "/~backend/v3/sessions.gettokens",
+  ],
+};
 
 function requestDisposition(methodValue, urlValue) {
   const method = String(methodValue || "GET").toUpperCase();
   if (["GET", "HEAD", "OPTIONS"].includes(method)) return "continue";
-  let action = "";
-  try { action = new URL(String(urlValue || "")).pathname.replace(/\/$/, "").split("/").pop().toLowerCase(); } catch (_) {}
-  return method === "POST" && READ_ONLY_POST_ACTIONS.includes(action) ? "continue" : "fail";
+  try {
+    const parsed = new URL(String(urlValue || ""));
+    const route = parsed.pathname.replace(/\/$/, "").toLowerCase();
+    return method === "POST" && (READ_ONLY_POST_ROUTES[parsed.origin] || []).includes(route) ? "continue" : "fail";
+  } catch (_) {
+    return "fail";
+  }
 }
 
 const RENDERER_CONTRACT = {
@@ -46,7 +58,7 @@ const RENDERER_CONTRACT = {
   mutates_mail_state: false,
   blocks_non_idempotent_before_dispatch: true,
   network_offline_during_render: true,
-  read_only_post_actions: READ_ONLY_POST_ACTIONS,
+  read_only_post_routes: READ_ONLY_POST_ROUTES,
 };
 if (process.argv.includes("--print-contract")) {
   process.stdout.write(JSON.stringify(RENDERER_CONTRACT));

--- a/superhuman_mail/renderer_probe.js
+++ b/superhuman_mail/renderer_probe.js
@@ -412,6 +412,8 @@ async function main() {
     await client.send("Runtime.enable");
     await client.send("Network.enable");
     await client.send("Page.enable");
+    client.events = [];
+    client.interceptions = [];
     await client.send("Fetch.enable", { patterns: [{ urlPattern: "*", requestStage: "Request" }] });
     await client.send("Network.emulateNetworkConditions", {
       offline: true,
@@ -420,8 +422,6 @@ async function main() {
       uploadThroughput: 0,
     });
     networkOffline = true;
-    client.events = [];
-    client.interceptions = [];
     // The probe never focuses/navigates. Fetch interception and offline mode
     // are active before render work so an autosave or other non-idempotent
     // request is aborted before any bytes are dispatched.

--- a/superhuman_mail/renderer_probe.js
+++ b/superhuman_mail/renderer_probe.js
@@ -1,0 +1,430 @@
+#!/usr/bin/env node
+"use strict";
+
+// Read-only CDP probe for the exact live Superhuman DraftModel/editor and
+// OutgoingMessage.toJsonRequest() pipeline. It never navigates, types, saves,
+// or calls a mail endpoint. The requested draft must already be open.
+
+const fs = require("fs");
+const path = require("path");
+const { execFileSync } = require("child_process");
+if (typeof WebSocket !== "function") {
+  throw new Error("Node.js 22+ is required for the exact renderer probe");
+}
+
+function arg(name, fallback) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 && process.argv[index + 1] ? process.argv[index + 1] : fallback;
+}
+
+const cdpBase = arg("--cdp", "http://127.0.0.1:9222").replace(/\/$/, "");
+const outputDir = path.resolve(arg("--output", process.cwd()));
+const input = JSON.parse(fs.readFileSync(0, "utf8"));
+fs.mkdirSync(outputDir, { recursive: true, mode: 0o700 });
+try { fs.chmodSync(outputDir, 0o700); } catch (_) {}
+
+class CDP {
+  constructor(url) {
+    this.url = url;
+    this.ws = null;
+    this.sequence = 0;
+    this.pending = new Map();
+    this.events = [];
+  }
+
+  async connect() {
+    this.ws = new WebSocket(this.url);
+    await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("CDP websocket open timeout")), 10000);
+      this.ws.addEventListener("open", () => { clearTimeout(timer); resolve(); }, { once: true });
+      this.ws.addEventListener("error", () => { clearTimeout(timer); reject(new Error("CDP websocket error")); }, { once: true });
+    });
+    this.ws.addEventListener("message", (event) => {
+      const message = JSON.parse(String(event.data));
+      if (message.id) {
+        const pending = this.pending.get(message.id);
+        if (!pending) return;
+        this.pending.delete(message.id);
+        if (message.error) pending.reject(new Error(`${pending.method}: ${message.error.message}`));
+        else pending.resolve(message.result || {});
+      } else if (message.method === "Network.requestWillBeSent") {
+        const request = message.params && message.params.request || {};
+        this.events.push({ method: request.method || "GET", url: request.url || "" });
+      }
+    });
+  }
+
+  send(method, params = {}, timeoutMs = 30000) {
+    const id = ++this.sequence;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`${method}: timed out`));
+      }, timeoutMs);
+      this.pending.set(id, {
+        method,
+        resolve: value => { clearTimeout(timer); resolve(value); },
+        reject: error => { clearTimeout(timer); reject(error); },
+      });
+      this.ws.send(JSON.stringify({ id, method, params }));
+    });
+  }
+
+  close() {
+    if (this.ws) this.ws.close();
+  }
+}
+
+function expressionFor(request) {
+  const encoded = JSON.stringify(request);
+  return `
+(async () => {
+  "use strict";
+  const request = ${encoded};
+  const seenFibers = new WeakSet();
+  const drafts = [];
+  const viewStates = [];
+  const editors = [];
+
+  function maybe(value) {
+    if (!value || (typeof value !== "object" && typeof value !== "function")) return;
+    try {
+      if (
+        value.id === request.draft_id &&
+        value.threadId === request.thread_id &&
+        typeof value.getBody === "function" &&
+        typeof value.json === "function" &&
+        typeof value.clone === "function"
+      ) drafts.push(value);
+      if (
+        value.account && value.tree &&
+        typeof value.getSignature === "function" &&
+        value.account.di
+      ) viewStates.push(value);
+      if (
+        typeof value.getHTMLSafe === "function" &&
+        value.props && value.props.draft &&
+        value.props.draft.id === request.draft_id
+      ) editors.push(value);
+    } catch (_) {}
+  }
+
+  for (const element of document.querySelectorAll("*")) {
+    for (const key of Object.keys(element)) {
+      if (!key.startsWith("__reactInternalInstance$") && !key.startsWith("__reactFiber$")) continue;
+      let fiber = element[key];
+      let hops = 0;
+      while (fiber && hops++ < 100) {
+        if (seenFibers.has(fiber)) break;
+        seenFibers.add(fiber);
+        maybe(fiber.stateNode);
+        for (const props of [fiber.memoizedProps, fiber.pendingProps]) {
+          if (!props || typeof props !== "object") continue;
+          maybe(props.draft);
+          maybe(props.viewState);
+          maybe(props.account);
+          maybe(props.composeFormController);
+        }
+        fiber = fiber.return;
+      }
+    }
+  }
+
+  const draft = drafts.find(candidate => candidate.id === request.draft_id && candidate.threadId === request.thread_id);
+  if (!draft) throw new Error("DRAFT_MODEL_NOT_FOUND: open the exact draft in Superhuman before attesting");
+
+  const editor = editors.find(candidate => candidate.props && candidate.props.draft === draft) || editors[0];
+  if (!editor) throw new Error("EDITOR_NOT_FOUND: exact Superhuman editor instance is unavailable");
+  const viewState = (editor.props && editor.props.viewState) || viewStates[0];
+  if (!viewState) throw new Error("VIEW_STATE_NOT_FOUND: exact Superhuman renderer context is unavailable");
+
+  const account = viewState.account;
+  const accountEmail = String(
+    account.emailAddress ||
+    (account.user && account.user.emailAddress) ||
+    (account.get && account.get("emailAddress")) ||
+    ""
+  );
+  if (accountEmail.toLowerCase() !== String(request.account_email).toLowerCase()) {
+    throw new Error("ACCOUNT_MISMATCH: renderer account differs from request");
+  }
+
+  const dirty = Boolean(
+    (typeof draft.isDirty === "function" && draft.isDirty()) ||
+    (editor.props && editor.props.draft && typeof editor.props.draft.isDirty === "function" && editor.props.draft.isDirty())
+  );
+  if (dirty) throw new Error("DIRTY_DRAFT: live draft has unsaved changes");
+
+  const editorHtml = String(editor.getHTMLSafe());
+  const liveJson = draft.json();
+  const renderDraft = draft.clone();
+  renderDraft.set({ body: editorHtml }, false);
+
+  const settings = account.di.get("settings");
+  const messageModel = renderDraft.asMessage(account.di);
+  // asMessage() creates an ephemeral MessageModel. Reusing the reserved ID on
+  // that object drives the actual getDraftHtmlBody -> OutgoingMessage.fromDraft
+  // -> BodyContent.generateForOutgoingMessage path without touching live state.
+  messageModel.sending = { superhumanId: request.superhuman_id };
+  const htmlBody = await Promise.race([
+    messageModel.getDraftHtmlBody(settings, viewState),
+    new Promise((_, reject) => setTimeout(() => reject(new Error("OUTGOING_RENDER_TIMEOUT")), 15000)),
+  ]);
+  const thread = messageModel.thread;
+
+  const includeSignatureOnReplies = viewState.tree.get("userSettings", "includeSignatureOnReplies");
+  let signature = null;
+  let signatureInlineAttachmentCount = 0;
+  try {
+    const model = viewState.getSignature(renderDraft.from);
+    if (model) {
+      signatureInlineAttachmentCount = Array.isArray(model.inlineImageAttachments) ? model.inlineImageAttachments.length : 0;
+      if (typeof model.toJson === "function") signature = model.toJson();
+      else if (typeof model.json === "function") signature = model.json();
+      else if (model.attributes) signature = model.attributes;
+      else signature = { is_empty: typeof model.isEmpty === "function" ? model.isEmpty() : null };
+    }
+  } catch (_) {
+    signature = { unavailable: true };
+  }
+  if (signatureInlineAttachmentCount > 0 || /src=["']data:/i.test(htmlBody)) {
+    throw new Error("SIGNATURE_INLINE_UPLOAD_UNSUPPORTED: exact read-only probe cannot materialize signature uploads");
+  }
+
+  const configElement = document.querySelector('script[type="x-superhuman/config"]');
+  let codeVersion = "";
+  try { codeVersion = JSON.parse(configElement && configElement.textContent || "{}").version || ""; } catch (_) {}
+  if (!codeVersion) throw new Error("WEB_CODE_VERSION_NOT_FOUND");
+  const appMatch = navigator.userAgent.match(/Superhuman[/]([0-9.]+)/);
+  const xMailer = (appMatch ? "Superhuman Desktop" : "Superhuman Web") + " (" + codeVersion + ")";
+
+  const attributes = renderDraft.attributes || {};
+  const threadId = thread && thread.id || renderDraft.threadId;
+  const headers = [
+    { name: "X-Mailer", value: xMailer },
+    { name: "X-Superhuman-ID", value: request.superhuman_id },
+    { name: "X-Superhuman-Draft-ID", value: renderDraft.id },
+  ];
+  if (String(threadId).startsWith("draft")) headers.push({ name: "X-Superhuman-Thread-ID", value: threadId });
+  if (renderDraft.getInReplyToRfc822Id()) headers.push({ name: "In-Reply-To", value: renderDraft.getInReplyToRfc822Id() });
+  const references = renderDraft.getReferences();
+  if (references.length) headers.push({ name: "References", value: references.join(" ") });
+
+  function attachmentRequest(attachment) {
+    const metadata = attachment.metadataJson();
+    const source = metadata.source || {};
+    return {
+      uuid: metadata.uuid,
+      cid: metadata.cid,
+      name: metadata.name,
+      type: metadata.type,
+      inline: metadata.inline,
+      source: {
+        type: source.type,
+        thread_id: source.threadId,
+        message_id: source.messageId,
+        attachment_id: source.attachmentId,
+        fixed_part_id: source.fixedPartId,
+        uuid: source.uuid,
+        cid: source.cid,
+      },
+    };
+  }
+
+  // This is the version-gated toJsonRequest contract for the allowlisted build.
+  // The body bytes themselves came from Superhuman's live private renderer above.
+  const payload = JSON.parse(JSON.stringify({
+    headers,
+    superhuman_id: request.superhuman_id,
+    rfc822_id: renderDraft.getRfc822Id(),
+    thread_id: threadId,
+    message_id: renderDraft.id,
+    in_reply_to: renderDraft.getInReplyTo(),
+    from: renderDraft.getFrom().toMinimalJson(),
+    to: renderDraft.getTo().map(contact => contact.toMinimalJson()),
+    cc: renderDraft.getCc().map(contact => contact.toMinimalJson()),
+    bcc: renderDraft.getBcc().map(contact => contact.toMinimalJson()),
+    subject: renderDraft.getSubject(),
+    html_body: htmlBody,
+    attachments: renderDraft.getAttachments().map(attachmentRequest),
+    scheduled_for: renderDraft.scheduledFor ? renderDraft.scheduledFor.toISOString() : undefined,
+    abort_on_reply: renderDraft.abortOnReply || false,
+    current_message_ids: thread && thread.messageIds,
+    mail_merge_recipients: attributes.mailMergeRecipients || [],
+    sensitivity_label_id: attributes.sensitivityLabelId,
+    sensitivity_tenant_id: attributes.sensitivityTenantId,
+  }));
+
+  return {
+    account_email: accountEmail,
+    thread_id: String(draft.threadId),
+    draft_id: String(draft.id),
+    dirty,
+    live_draft_json: liveJson,
+    editor_html: editorHtml,
+    outgoing_payload: payload,
+    signature_settings: {
+      include_signature_on_replies: includeSignatureOnReplies,
+      signature,
+    },
+    app_version: appMatch ? appMatch[1] : "web",
+    web_version: codeVersion,
+    surface: appMatch ? "superhuman-desktop" : "superhuman-web",
+  };
+})()
+`;
+}
+
+async function evaluate(client, expression) {
+  const response = await client.send("Runtime.evaluate", {
+    expression,
+    awaitPromise: true,
+    returnByValue: true,
+    userGesture: false,
+  });
+  if (response.exceptionDetails) {
+    const detail = response.exceptionDetails.exception && response.exceptionDetails.exception.description ||
+      response.exceptionDetails.text || "Runtime evaluation failed";
+    throw new Error(detail);
+  }
+  return response.result && response.result.value;
+}
+
+async function main() {
+  const targetsResponse = await fetch(`${cdpBase}/json/list`);
+  if (!targetsResponse.ok) throw new Error(`CDP discovery failed: HTTP ${targetsResponse.status}`);
+  const targets = await targetsResponse.json();
+  const exactThreadPath = `/thread/${input.thread_id}`;
+  const candidates = targets.filter(item =>
+    item.type === "page" &&
+    String(item.url || "").startsWith("https://mail.superhuman.com/") &&
+    !String(item.url || "").includes("background_page") &&
+    item.webSocketDebuggerUrl
+  );
+  let target = null;
+  let firstModelTarget = null;
+  const modelCheck = `(() => {
+    const wanted = ${JSON.stringify(input.draft_id)};
+    const seen = new WeakSet();
+    for (const element of document.querySelectorAll("*")) {
+      for (const key of Object.keys(element)) {
+        if (!key.startsWith("__reactInternalInstance$") && !key.startsWith("__reactFiber$")) continue;
+        let fiber = element[key], hops = 0;
+        while (fiber && hops++ < 100) {
+          if (seen.has(fiber)) break;
+          seen.add(fiber);
+          const props = fiber.memoizedProps;
+          if (props && props.draft && props.draft.id === wanted) return true;
+          fiber = fiber.return;
+        }
+      }
+    }
+    return false;
+  })()`;
+  for (const candidate of candidates) {
+    const inspector = new CDP(candidate.webSocketDebuggerUrl);
+    try {
+      await inspector.connect();
+      const checked = await inspector.send("Runtime.evaluate", {
+        expression: `JSON.stringify({ visible: document.visibilityState === "visible", hasModel: ${modelCheck} })`,
+        returnByValue: true,
+      });
+      const value = JSON.parse(checked.result && checked.result.value || "{}");
+      if (value.hasModel && !firstModelTarget) firstModelTarget = candidate;
+      if (value.hasModel && value.visible) {
+        target = candidate;
+        break;
+      }
+    } catch (_) {
+      // Try the next renderer target.
+    } finally {
+      inspector.close();
+    }
+  }
+  target = target || firstModelTarget || candidates.find(item => String(item.url || "").includes(exactThreadPath));
+  if (!target) throw new Error("No visible Superhuman page target found on the CDP endpoint");
+  if (process.env.SHM_RENDERER_DEBUG) process.stderr.write(`probe:target ${target.id} ${target.url}\n`);
+
+  const client = new CDP(target.webSocketDebuggerUrl);
+  await client.connect();
+  try {
+    await client.send("Runtime.enable");
+    await client.send("Network.enable");
+    await client.send("Page.enable");
+    client.events = [];
+    await client.send("Page.bringToFront");
+
+    const renderExpression = expressionFor(input);
+    if (process.env.SHM_RENDERER_DEBUG_EXPRESSION) {
+      fs.writeFileSync(process.env.SHM_RENDERER_DEBUG_EXPRESSION, renderExpression);
+    }
+    const result = await evaluate(client, renderExpression);
+    if (process.env.SHM_RENDERER_DEBUG) process.stderr.write("probe:evaluated\n");
+    if (!result || typeof result !== "object") throw new Error("Renderer expression returned no result");
+
+    async function capture(pathname, clip) {
+      try {
+        const shot = await client.send(
+          "Page.captureScreenshot",
+          { format: "png", fromSurface: true, ...(clip ? { clip } : {}) },
+          5000,
+        );
+        fs.writeFileSync(pathname, Buffer.from(shot.data, "base64"), { mode: 0o600 });
+        return;
+      } catch (error) {
+        if (!input.window_id || process.platform !== "darwin") {
+          throw new Error(`SCREENSHOT_UNAVAILABLE: ${error.message}; provide --window-id on macOS`);
+        }
+        execFileSync("/usr/sbin/screencapture", ["-x", "-l", String(input.window_id), pathname], {
+          stdio: "ignore",
+          timeout: 10000,
+        });
+        fs.chmodSync(pathname, 0o600);
+      }
+    }
+
+    const composePath = path.join(outputDir, "compose.png");
+    await capture(composePath);
+    if (process.env.SHM_RENDERER_DEBUG) process.stderr.write("probe:compose-shot\n");
+
+    // A sandboxed, network-disabled transport-byte view. The exact payload is
+    // the authority; this screenshot is supporting visual evidence only.
+    const html = String(result.outgoing_payload && result.outgoing_payload.html_body || "");
+    const overlayExpression = `
+      (async () => {
+        const old = document.getElementById("__shm_attestation_overlay");
+        if (old) old.remove();
+        const host = document.createElement("div");
+        host.id = "__shm_attestation_overlay";
+        host.style.cssText = "position:fixed;inset:24px;z-index:2147483647;background:white;border:1px solid #aaa;overflow:auto;padding:24px;";
+        const frame = document.createElement("iframe");
+        frame.sandbox = "";
+        frame.style.cssText = "width:100%;height:100%;border:0;background:white;";
+        const policy = '<meta http-equiv="Content-Security-Policy" content="default-src \\'none\\'; style-src \\'unsafe-inline\\'; img-src data: cid:">';
+        frame.srcdoc = policy + ${JSON.stringify(html)};
+        host.appendChild(frame);
+        document.body.appendChild(host);
+        await new Promise(resolve => setTimeout(resolve, 100));
+        const rect = host.getBoundingClientRect();
+        return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+      })()
+    `;
+    const rect = await evaluate(client, overlayExpression);
+    if (process.env.SHM_RENDERER_DEBUG) process.stderr.write("probe:overlay\n");
+    const outgoingPath = path.join(outputDir, "outgoing.png");
+    await capture(outgoingPath, { x: rect.x, y: rect.y, width: rect.width, height: rect.height, scale: 1 });
+    if (process.env.SHM_RENDERER_DEBUG) process.stderr.write("probe:outgoing-shot\n");
+    await evaluate(client, `(() => { const node = document.getElementById("__shm_attestation_overlay"); if (node) node.remove(); return true; })()`);
+
+    result.network_events = client.events;
+    result.screenshots = [composePath, outgoingPath];
+    process.stdout.write(JSON.stringify(result));
+  } finally {
+    client.close();
+  }
+}
+
+main().catch(error => {
+  process.stderr.write(String(error && error.stack || error) + "\n");
+  process.exitCode = 1;
+});

--- a/superhuman_mail/renderer_probe.js
+++ b/superhuman_mail/renderer_probe.js
@@ -17,6 +17,22 @@ function arg(name, fallback) {
   return index >= 0 && process.argv[index + 1] ? process.argv[index + 1] : fallback;
 }
 
+const RENDERER_CONTRACT = {
+  adapter_version: "superhuman-cdp-v1",
+  outgoing_fields: [
+    "headers", "superhuman_id", "rfc822_id", "thread_id", "message_id",
+    "in_reply_to", "from", "to", "cc", "bcc", "subject", "html_body",
+    "attachments", "scheduled_for", "abort_on_reply", "current_message_ids",
+    "mail_merge_recipients", "sensitivity_label_id", "sensitivity_tenant_id",
+  ],
+  reminder: "persisted_draft_only_current_build",
+  mutates_mail_state: false,
+};
+if (process.argv.includes("--print-contract")) {
+  process.stdout.write(JSON.stringify(RENDERER_CONTRACT));
+  process.exit(0);
+}
+
 const cdpBase = arg("--cdp", "http://127.0.0.1:9222").replace(/\/$/, "");
 const outputDir = path.resolve(arg("--output", process.cwd()));
 const input = JSON.parse(fs.readFileSync(0, "utf8"));
@@ -251,6 +267,9 @@ function expressionFor(request) {
     abort_on_reply: renderDraft.abortOnReply || false,
     current_message_ids: thread && thread.messageIds,
     mail_merge_recipients: attributes.mailMergeRecipients || [],
+    // The allowlisted OutgoingMessage.fromDraft() does not copy reminder into
+    // its attributes; toJsonRequest() therefore omits it. The persisted draft
+    // remains fingerprint-bound so reminder drift still fails the second probe.
     sensitivity_label_id: attributes.sensitivityLabelId,
     sensitivity_tenant_id: attributes.sensitivityTenantId,
   }));

--- a/superhuman_mail/send.py
+++ b/superhuman_mail/send.py
@@ -417,6 +417,44 @@ def _reconcile(
     last_state: dict[str, Any] | None = None
     last_attempt = attempt
 
+    if (
+        attempt.get("state") == lifecycle.PROVIDER_CONFIRMED
+        and attempt.get("provider_message_id")
+    ):
+        tombstone = {
+            "account": {
+                "email": account,
+                "provider_user_id": attempt["account_id"],
+            },
+            "thread_id": attempt["thread_id"],
+            "draft_id": attempt["draft_id"],
+            "state": lifecycle.PROVIDER_CONFIRMED,
+            "terminal": True,
+            "send_blocked": True,
+            "outbound_evidence": True,
+            "confidence": "provider_confirmed_journal_tombstone",
+            "consistency": "journal_tombstone",
+            "timestamps": {
+                "sent_at": attempt.get("backend_sent_at"),
+                "provider_message_at": attempt.get("provider_sent_at"),
+            },
+            "send_job": {
+                "superhuman_id": attempt.get("superhuman_id"),
+                "present": True,
+            },
+            "provider_message": {
+                "id": attempt["provider_message_id"],
+                "thread_id": attempt["thread_id"],
+                "labels": ["SENT"],
+            },
+            "observations": [{
+                "source": "local_attempt_journal",
+                "observed_at": datetime_now_iso(),
+            }],
+        }
+        warnings.append("Using immutable provider-confirmed journal tombstone")
+        return attempt, tombstone, warnings
+
     while True:
         state, _wrapper, observed_warnings = lifecycle.observe(
             attempt["thread_id"],

--- a/superhuman_mail/send.py
+++ b/superhuman_mail/send.py
@@ -148,7 +148,8 @@ def _build_outgoing(draft: dict[str, Any], sid: str | None = None) -> dict[str, 
     for key, val in {
         "scheduled_for": draft.get("scheduledFor"),
         "abort_on_reply": draft.get("abortOnReply"),
-        "reminder": draft.get("reminder"),
+        # Current Superhuman OutgoingMessage.fromDraft() does not copy the
+        # draft reminder into toJsonRequest(); the persisted draft owns it.
         "sensitivity_label_id": draft.get("sensitivityLabelId"),
         "sensitivity_tenant_id": draft.get("sensitivityTenantId"),
     }.items():
@@ -163,6 +164,7 @@ def _build_outgoing(draft: dict[str, Any], sid: str | None = None) -> dict[str, 
 # ---------------------------------------------------------------------------
 
 SEND_DELAY_SECONDS = 20
+APPROVAL_AUTHORITY = "correlation_only"
 
 
 class SendSafetyError(RuntimeError):
@@ -281,7 +283,14 @@ def _preflight(
 def validate(thread_id: str, draft_id: str, *, account: str | None = None) -> dict[str, Any]:
     """Read-only metadata preflight. Exact render attestation remains required."""
     try:
-        checked = _preflight(thread_id, draft_id, account=account)
+        if not account:
+            raise SendSafetyError("ACCOUNT_REQUIRED", "--account is required for send preflight", cls="input")
+        checked = _preflight(
+            thread_id,
+            draft_id,
+            account=account,
+            require_explicit_account=True,
+        )
         draft = checked["draft"]
         outgoing = checked["outgoing"]
         result: dict[str, Any] = {
@@ -299,7 +308,10 @@ def validate(thread_id: str, draft_id: str, *, account: str | None = None) -> di
             "body_preview": (draft.get("snippet") or "")[:200],
             "has_attachments": bool(outgoing.get("attachments")),
             "lifecycle": checked["lifecycle"],
-            "next_step": "Create an exact render attestation before --confirm",
+            "approval_authority": APPROVAL_AUTHORITY,
+            "approval_verified": False,
+            "unattended_send_eligible": False,
+            "next_step": "Create an exact render attestation and obtain external operator approval before --confirm",
         }
         for draft_key, result_key in {
             "scheduledFor": "scheduled_for",
@@ -336,10 +348,25 @@ def _post_exact_payload(outgoing: dict[str, Any], *, delay: int) -> None:
         resp.read()
 
 
-def _attempt_result(attempt: dict[str, Any], state: dict[str, Any], *, accepted: bool) -> dict[str, Any]:
+def _request_accepted(attempt: dict[str, Any], state: dict[str, Any]) -> bool:
+    return bool(
+        attempt.get("response_class") == "http_2xx"
+        or state["state"] in {
+            lifecycle.SCHEDULED,
+            lifecycle.BACKEND_CONFIRMED,
+            lifecycle.PROVIDER_CONFIRMED,
+            lifecycle.FAILED,
+            lifecycle.ABORTED,
+        }
+    )
+
+
+def _attempt_result(attempt: dict[str, Any], state: dict[str, Any]) -> dict[str, Any]:
     provider_confirmed = state["state"] == lifecycle.PROVIDER_CONFIRMED
+    post_claimed = int(attempt["post_count"]) > 0
+    accepted = _request_accepted(attempt, state)
     material_state = state["state"]
-    if accepted and material_state == lifecycle.ACTIVE and attempt.get("state") == "unknown":
+    if post_claimed and material_state == lifecycle.ACTIVE and attempt.get("state") == "unknown":
         material_state = "unknown"
     return {
         "attempt_id": attempt["attempt_id"],
@@ -347,12 +374,16 @@ def _attempt_result(attempt: dict[str, Any], state: dict[str, Any], *, accepted:
         "draft_id": attempt["draft_id"],
         "attestation_id": attempt["attestation_id"],
         "state": material_state,
+        "post_claimed": post_claimed,
         "accepted": accepted,
         "sent": provider_confirmed,
         "provider_confirmed": provider_confirmed,
         "outbound_evidence": bool(state["outbound_evidence"]),
         "superhuman_id": attempt["superhuman_id"],
         "provider_message_id": (state.get("provider_message") or {}).get("id"),
+        "approval_authority": APPROVAL_AUTHORITY,
+        "approval_verified": False,
+        "unattended_send_eligible": False,
         "idempotency_scope": _attempts.IDEMPOTENCY_SCOPE,
         "lifecycle": state,
     }
@@ -426,10 +457,20 @@ def _reconcile(
             last_attempt = journal.update(attempt["attempt_id"], state="unknown", **update)
             return last_attempt, state, warnings
         else:
-            # An active source after a POST claim is an unknown/lagging outcome,
-            # never permission to mint another ID or post again.
-            attempt_state = state_name if state_name != lifecycle.ACTIVE else "unknown"
-            last_attempt = journal.update(attempt["attempt_id"], state=attempt_state, **update)
+            if (
+                state_name == lifecycle.ACTIVE
+                and int(attempt["post_count"]) == 0
+                and attempt.get("state") == "prepared"
+            ):
+                # A read-tier status check must not convert a never-posted,
+                # safely claimable row into an irreversible unknown outcome.
+                last_attempt = journal.update(attempt["attempt_id"], **update)
+                return last_attempt, state, warnings
+            else:
+                # An active source after a POST claim is an unknown/lagging
+                # outcome, never permission to mint another ID or post again.
+                attempt_state = state_name if state_name != lifecycle.ACTIVE else "unknown"
+                last_attempt = journal.update(attempt["attempt_id"], state=attempt_state, **update)
 
         now = monotonic()
         if now >= deadline:
@@ -459,13 +500,18 @@ def status(
         journal = journal or _attempts.AttemptJournal()
         attempt = journal.get(identity["provider_user_id"], draft_id)
         if attempt:
+            if attempt["thread_id"] != thread_id:
+                raise SendSafetyError(
+                    "ATTEMPT_THREAD_MISMATCH",
+                    "The local attempt for this draft belongs to a different thread",
+                )
             updated, state, observed_warnings = _reconcile(
                 attempt,
                 account=identity["email"],
                 wait=wait,
                 journal=journal,
             )
-            return ok("send.status", _attempt_result(updated, state, accepted=int(updated["post_count"]) > 0), warnings=warnings + observed_warnings)
+            return ok("send.status", _attempt_result(updated, state), warnings=warnings + observed_warnings)
         deadline = time.monotonic() + max(0.0, wait)
         interval = 0.25
         observed_warnings: list[str] = []
@@ -499,6 +545,7 @@ def status(
             "thread_id": thread_id,
             "draft_id": draft_id,
             "state": state["state"],
+            "post_claimed": False,
             "accepted": state["state"] in {
                 lifecycle.SCHEDULED,
                 lifecycle.REQUESTED,
@@ -513,9 +560,14 @@ def status(
             "outbound_evidence": state["outbound_evidence"],
             "superhuman_id": (state.get("send_job") or {}).get("superhuman_id"),
             "provider_message_id": (state.get("provider_message") or {}).get("id"),
+            "approval_authority": APPROVAL_AUTHORITY,
+            "approval_verified": False,
+            "unattended_send_eligible": False,
             "idempotency_scope": _attempts.IDEMPOTENCY_SCOPE,
             "lifecycle": state,
         }, warnings=warnings + observed_warnings)
+    except SendSafetyError as exc:
+        return _safety_failure("send.status", exc)
     except Exception as exc:
         return fail("send.status", [classify_exception(exc)])
 
@@ -552,8 +604,10 @@ def execute(
                 allow_empty_subject=True,
             )
             raise SendSafetyError("ATTESTATION_REQUIRED", "--attestation is required for strict send", cls="input")
-        if not approval_ref:
+        if not approval_ref or not approval_ref.strip():
             raise SendSafetyError("APPROVAL_REFERENCE_REQUIRED", "--approval-ref is required for strict send", cls="input")
+        if len(approval_ref) > 512:
+            raise SendSafetyError("APPROVAL_REFERENCE_INVALID", "--approval-ref must be 512 characters or fewer", cls="input")
         if delay < 0:
             raise SendSafetyError("INVALID_DELAY", "--delay must be non-negative", cls="input")
 
@@ -589,12 +643,15 @@ def execute(
                 wait=wait,
                 journal=journal,
             )
-            data = _attempt_result(updated, state, accepted=True)
+            data = _attempt_result(updated, state)
             if state["state"] in {lifecycle.FAILED, lifecycle.ABORTED, lifecycle.INCONSISTENT}:
                 code = "SEND_TERMINAL_FAILURE" if state["state"] != lifecycle.INCONSISTENT else "LIFECYCLE_INCONSISTENT"
                 return fail("send", [error("conflict", code, False, f"Attempt reconciled to {state['state']}")], warnings=warnings)
             if not data["sent"] and state["state"] != lifecycle.SCHEDULED:
-                warnings.append("Attempt remains pending/unknown; no additional POST was made")
+                if data["post_claimed"]:
+                    warnings.append("Attempt remains pending/unknown; no additional POST was made")
+                else:
+                    warnings.append("No local POST was claimed; lifecycle evidence is not provider-confirmed")
             return ok("send", data, warnings=account_warnings + warnings)
 
         if attempt is None:
@@ -628,7 +685,15 @@ def execute(
                 superhuman_id=str(record["superhuman_id"]),
                 outgoing_fingerprint=str(record["fingerprint"]["exact"]),
             )
-        attempt, claimed = journal.claim_post(attempt["attempt_id"])
+        try:
+            attempt, claimed = journal.claim_post(attempt["attempt_id"])
+        except KeyError as exc:
+            replacement = journal.get(identity["provider_user_id"], draft_id)
+            if replacement is not None:
+                raise _attempts.AttemptConflict(
+                    "Attempt identity changed concurrently; inspect send status before retrying"
+                ) from exc
+            raise
         if not claimed:
             updated, state, warnings = _reconcile(
                 attempt,
@@ -636,7 +701,7 @@ def execute(
                 wait=wait,
                 journal=journal,
             )
-            return ok("send", _attempt_result(updated, state, accepted=int(updated["post_count"]) > 0), warnings=account_warnings + warnings)
+            return ok("send", _attempt_result(updated, state), warnings=account_warnings + warnings)
 
         try:
             _post_exact_payload(verified["outgoing_payload"], delay=delay)
@@ -658,12 +723,15 @@ def execute(
             wait=wait,
             journal=journal,
         )
-        data = _attempt_result(updated, state, accepted=True)
+        data = _attempt_result(updated, state)
         if state["state"] in {lifecycle.FAILED, lifecycle.ABORTED, lifecycle.INCONSISTENT}:
             code = "SEND_TERMINAL_FAILURE" if state["state"] != lifecycle.INCONSISTENT else "LIFECYCLE_INCONSISTENT"
             return fail("send", [error("conflict", code, False, f"Attempt reconciled to {state['state']}")], warnings=warnings)
         if not data["sent"] and state["state"] != lifecycle.SCHEDULED:
-            warnings.append("Request was accepted or outcome is unknown; provider delivery is not yet confirmed")
+            if data["accepted"]:
+                warnings.append("Request was accepted; provider delivery is not yet confirmed")
+            else:
+                warnings.append("A POST was claimed, but server acceptance is unknown; no retry was attempted")
         return ok("send", data, warnings=account_warnings + warnings)
     except SendSafetyError as exc:
         return _safety_failure("send", exc)

--- a/superhuman_mail/send.py
+++ b/superhuman_mail/send.py
@@ -13,7 +13,7 @@ from email.utils import parseaddr
 from html import unescape
 from typing import Any
 
-from . import _auth, attestation as _attestation, attempts as _attempts, lifecycle
+from . import _auth, approval as _approval, attestation as _attestation, attempts as _attempts, lifecycle
 from ._envelope import classify_exception, error, fail, ok
 
 # ---------------------------------------------------------------------------
@@ -164,7 +164,6 @@ def _build_outgoing(draft: dict[str, Any], sid: str | None = None) -> dict[str, 
 # ---------------------------------------------------------------------------
 
 SEND_DELAY_SECONDS = 20
-APPROVAL_AUTHORITY = "correlation_only"
 
 
 class SendSafetyError(RuntimeError):
@@ -308,10 +307,12 @@ def validate(thread_id: str, draft_id: str, *, account: str | None = None) -> di
             "body_preview": (draft.get("snippet") or "")[:200],
             "has_attachments": bool(outgoing.get("attachments")),
             "lifecycle": checked["lifecycle"],
-            "approval_authority": APPROVAL_AUTHORITY,
+            "approval_authority": "external_receipt_required",
             "approval_verified": False,
+            "approval_consumed": False,
             "unattended_send_eligible": False,
-            "next_step": "Create an exact render attestation and obtain external operator approval before --confirm",
+            "trusted_executor_required": True,
+            "next_step": "Create an exact render attestation and obtain an external signed approval receipt",
         }
         for draft_key, result_key in {
             "scheduledFor": "scheduled_for",
@@ -348,17 +349,23 @@ def _post_exact_payload(outgoing: dict[str, Any], *, delay: int) -> None:
         resp.read()
 
 
-def _request_accepted(attempt: dict[str, Any], state: dict[str, Any]) -> bool:
+def _lifecycle_request_accepted(state: dict[str, Any]) -> bool:
+    if state["state"] in {
+        lifecycle.SCHEDULED,
+        lifecycle.BACKEND_CONFIRMED,
+        lifecycle.PROVIDER_CONFIRMED,
+    }:
+        return True
+    send_job = state.get("send_job") or {}
     return bool(
-        attempt.get("response_class") == "http_2xx"
-        or state["state"] in {
-            lifecycle.SCHEDULED,
-            lifecycle.BACKEND_CONFIRMED,
-            lifecycle.PROVIDER_CONFIRMED,
-            lifecycle.FAILED,
-            lifecycle.ABORTED,
-        }
+        state["state"] in {lifecycle.FAILED, lifecycle.ABORTED}
+        and send_job.get("not_sent_to_server_present")
+        and not send_job.get("not_sent_to_server")
     )
+
+
+def _request_accepted(attempt: dict[str, Any], state: dict[str, Any]) -> bool:
+    return bool(attempt.get("response_class") == "http_2xx" or _lifecycle_request_accepted(state))
 
 
 def _attempt_result(attempt: dict[str, Any], state: dict[str, Any]) -> dict[str, Any]:
@@ -381,9 +388,14 @@ def _attempt_result(attempt: dict[str, Any], state: dict[str, Any]) -> dict[str,
         "outbound_evidence": bool(state["outbound_evidence"]),
         "superhuman_id": attempt["superhuman_id"],
         "provider_message_id": (state.get("provider_message") or {}).get("id"),
-        "approval_authority": APPROVAL_AUTHORITY,
-        "approval_verified": False,
+        "approval_authority": _approval.AUTHORITY if attempt.get("approval_receipt_id") else "external_receipt_required",
+        "approval_verified": bool(attempt.get("approval_receipt_id")),
+        "approval_consumed": post_claimed,
+        "approval_receipt_id": attempt.get("approval_receipt_id"),
+        "approval_issuer": attempt.get("approval_issuer"),
+        "approval_key_id": attempt.get("approval_key_id"),
         "unattended_send_eligible": False,
+        "trusted_executor_required": True,
         "idempotency_scope": _attempts.IDEMPOTENCY_SCOPE,
         "lifecycle": state,
     }
@@ -546,23 +558,17 @@ def status(
             "draft_id": draft_id,
             "state": state["state"],
             "post_claimed": False,
-            "accepted": state["state"] in {
-                lifecycle.SCHEDULED,
-                lifecycle.REQUESTED,
-                lifecycle.PENDING_UNDO,
-                lifecycle.BACKEND_CONFIRMED,
-                lifecycle.PROVIDER_CONFIRMED,
-                lifecycle.FAILED,
-                lifecycle.ABORTED,
-            },
+            "accepted": _lifecycle_request_accepted(state),
             "sent": state["state"] == lifecycle.PROVIDER_CONFIRMED,
             "provider_confirmed": state["state"] == lifecycle.PROVIDER_CONFIRMED,
             "outbound_evidence": state["outbound_evidence"],
             "superhuman_id": (state.get("send_job") or {}).get("superhuman_id"),
             "provider_message_id": (state.get("provider_message") or {}).get("id"),
-            "approval_authority": APPROVAL_AUTHORITY,
+            "approval_authority": "external_receipt_required",
             "approval_verified": False,
+            "approval_consumed": False,
             "unattended_send_eligible": False,
+            "trusted_executor_required": True,
             "idempotency_scope": _attempts.IDEMPOTENCY_SCOPE,
             "lifecycle": state,
         }, warnings=warnings + observed_warnings)
@@ -579,6 +585,7 @@ def execute(
     delay: int = SEND_DELAY_SECONDS,
     account: str | None = None,
     attestation: str | None = None,
+    approval_receipt: str | None = None,
     approval_ref: str | None = None,
     wait: float = 120,
     journal: _attempts.AttemptJournal | None = None,
@@ -604,10 +611,13 @@ def execute(
                 allow_empty_subject=True,
             )
             raise SendSafetyError("ATTESTATION_REQUIRED", "--attestation is required for strict send", cls="input")
-        if not approval_ref or not approval_ref.strip():
-            raise SendSafetyError("APPROVAL_REFERENCE_REQUIRED", "--approval-ref is required for strict send", cls="input")
-        if len(approval_ref) > 512:
-            raise SendSafetyError("APPROVAL_REFERENCE_INVALID", "--approval-ref must be 512 characters or fewer", cls="input")
+        if not approval_receipt:
+            hint = "--approval-ref is audit-only and cannot authorize a send; " if approval_ref else ""
+            raise SendSafetyError(
+                "APPROVAL_RECEIPT_REQUIRED",
+                hint + "--approval-receipt from the external approval broker is required",
+                cls="input",
+            )
         if delay < 0:
             raise SendSafetyError("INVALID_DELAY", "--delay must be non-negative", cls="input")
 
@@ -620,9 +630,19 @@ def execute(
         identity, account_warnings = lifecycle.resolve_account(account, require_explicit=True)
         if str(record.get("account", {}).get("provider_user_id")) != identity["provider_user_id"]:
             raise SendSafetyError("ACCOUNT_BINDING_MISMATCH", "Attestation belongs to a different immutable account identity")
+        _receipt, approval = _approval.load_and_verify(approval_receipt, attestation=record)
 
         journal = journal or _attempts.AttemptJournal()
         attempt = journal.get(identity["provider_user_id"], draft_id)
+        attempt_approval = {
+            "approval_receipt_id": approval["receipt_id"],
+            "approval_receipt_digest": approval["receipt_digest"],
+            "approval_issuer": approval["issuer"],
+            "approval_key_id": approval["key_id"],
+            "approval_approver": approval["approver"],
+            "approval_issued_at": approval["issued_at"],
+            "approval_expires_at": approval["expires_at"],
+        }
         if attempt is not None:
             # Validate that this invocation carries the same approved identity.
             attempt, _created = journal.create_or_get(
@@ -631,7 +651,7 @@ def execute(
                 thread_id=thread_id,
                 draft_id=draft_id,
                 attestation_id=str(record["attestation_id"]),
-                approval_ref=approval_ref,
+                **attempt_approval,
                 superhuman_id=str(record["superhuman_id"]),
                 outgoing_fingerprint=str(record["fingerprint"]["exact"]),
             )
@@ -681,12 +701,17 @@ def execute(
                 thread_id=thread_id,
                 draft_id=draft_id,
                 attestation_id=str(record["attestation_id"]),
-                approval_ref=approval_ref,
+                **attempt_approval,
                 superhuman_id=str(record["superhuman_id"]),
                 outgoing_fingerprint=str(record["fingerprint"]["exact"]),
             )
         try:
-            attempt, claimed = journal.claim_post(attempt["attempt_id"])
+            attempt, claimed = journal.claim_post(
+                attempt["attempt_id"],
+                approval_receipt_id=approval["receipt_id"],
+                approval_receipt_digest=approval["receipt_digest"],
+                approval_expires_at=approval["expires_at"],
+            )
         except KeyError as exc:
             replacement = journal.get(identity["provider_user_id"], draft_id)
             if replacement is not None:
@@ -736,6 +761,10 @@ def execute(
     except SendSafetyError as exc:
         return _safety_failure("send", exc)
     except _attestation.AttestationError as exc:
+        return fail("send", [error("conflict", exc.code, False, exc.hint)])
+    except _approval.ApprovalError as exc:
+        return fail("send", [error("conflict", exc.code, False, exc.hint)])
+    except _attempts.ReceiptClaimError as exc:
         return fail("send", [error("conflict", exc.code, False, exc.hint)])
     except _attempts.AttemptConflict as exc:
         return fail("send", [error("conflict", "ATTEMPT_CONFLICT", False, str(exc))])

--- a/superhuman_mail/send.py
+++ b/superhuman_mail/send.py
@@ -466,21 +466,53 @@ def status(
                 journal=journal,
             )
             return ok("send.status", _attempt_result(updated, state, accepted=int(updated["post_count"]) > 0), warnings=warnings + observed_warnings)
-        state, _wrapper, observed_warnings = lifecycle.observe(
-            thread_id,
-            draft_id,
-            account=identity["email"],
-            require_explicit_account=True,
-        )
+        deadline = time.monotonic() + max(0.0, wait)
+        interval = 0.25
+        observed_warnings: list[str] = []
+        while True:
+            state, _wrapper, current_warnings = lifecycle.observe(
+                thread_id,
+                draft_id,
+                account=identity["email"],
+                require_explicit_account=True,
+            )
+            observed_warnings.extend(item for item in current_warnings if item not in observed_warnings)
+            state_name = state["state"]
+            if state_name in {
+                lifecycle.ACTIVE,
+                lifecycle.SCHEDULED,
+                lifecycle.PROVIDER_CONFIRMED,
+                lifecycle.FAILED,
+                lifecycle.ABORTED,
+                lifecycle.DISCARDED,
+                lifecycle.INCONSISTENT,
+            }:
+                break
+            now = time.monotonic()
+            if now >= deadline:
+                break
+            time.sleep(min(interval, max(0.0, deadline - now)))
+            interval = min(interval * 2, 5.0)
         return ok("send.status", {
             "attempt_id": None,
+            "attestation_id": None,
             "thread_id": thread_id,
             "draft_id": draft_id,
             "state": state["state"],
-            "accepted": False,
+            "accepted": state["state"] in {
+                lifecycle.SCHEDULED,
+                lifecycle.REQUESTED,
+                lifecycle.PENDING_UNDO,
+                lifecycle.BACKEND_CONFIRMED,
+                lifecycle.PROVIDER_CONFIRMED,
+                lifecycle.FAILED,
+                lifecycle.ABORTED,
+            },
             "sent": state["state"] == lifecycle.PROVIDER_CONFIRMED,
             "provider_confirmed": state["state"] == lifecycle.PROVIDER_CONFIRMED,
             "outbound_evidence": state["outbound_evidence"],
+            "superhuman_id": (state.get("send_job") or {}).get("superhuman_id"),
+            "provider_message_id": (state.get("provider_message") or {}).get("id"),
             "idempotency_scope": _attempts.IDEMPOTENCY_SCOPE,
             "lifecycle": state,
         }, warnings=warnings + observed_warnings)

--- a/superhuman_mail/send.py
+++ b/superhuman_mail/send.py
@@ -4,14 +4,16 @@ Send is IRREVERSIBLE. The CLI requires --dry-run or --confirm.
 """
 from __future__ import annotations
 
-import json
+import re
 import time
 import urllib.request
 import uuid
+from email.headerregistry import Address
 from email.utils import parseaddr
+from html import unescape
 from typing import Any
 
-from . import _auth, _config, thread as _thread
+from . import _auth, attestation as _attestation, attempts as _attempts, lifecycle
 from ._envelope import classify_exception, error, fail, ok
 
 # ---------------------------------------------------------------------------
@@ -163,52 +165,142 @@ def _build_outgoing(draft: dict[str, Any], sid: str | None = None) -> dict[str, 
 SEND_DELAY_SECONDS = 20
 
 
-def validate(thread_id: str, draft_id: str) -> dict[str, Any]:
-    """Dry-run: read the draft and validate it's sendable.
+class SendSafetyError(RuntimeError):
+    """A deterministic execute-time safety guard rejected a draft."""
 
-    Returns draft details and any issues, WITHOUT actually sending.
-    """
+    def __init__(self, code: str, hint: str, *, cls: str = "conflict") -> None:
+        super().__init__(hint)
+        self.code = code
+        self.hint = hint
+        self.cls = cls
+
+
+def _safety_failure(command: str, exc: SendSafetyError) -> dict[str, Any]:
+    return fail(command, [error(exc.cls, exc.code, False, exc.hint)])
+
+
+def _valid_address(contact: Any) -> bool:
+    normalized = _contact_json(contact)
+    value = normalized.get("email", "").strip()
+    if not value or any(ch.isspace() for ch in value):
+        return False
     try:
-        ud = _thread.userdata_raw(thread_id)
-        if not ud:
-            return fail("send.validate", [error("not-found", "THREAD_NOT_FOUND", False, f"No userdata for thread {thread_id}")])
+        parsed = Address(addr_spec=value)
+    except (TypeError, ValueError):
+        return False
+    return bool(parsed.username and parsed.domain and "." in parsed.domain.rstrip("."))
 
-        msgs = ud.get("messages", {})
-        msg_data = msgs.get(draft_id, {})
-        draft = msg_data.get("draft")
-        if not draft:
-            return fail("send.validate", [error("not-found", "DRAFT_NOT_FOUND", False, f"Draft {draft_id} not found on thread {thread_id}")])
 
-        if msg_data.get("discardedAt"):
-            return fail("send.validate", [error("conflict", "DRAFT_DISCARDED", False, "Draft has been discarded")])
+def _body_has_content(value: str) -> bool:
+    if not value or not value.strip():
+        return False
+    text = unescape(re.sub(r"<[^>]*>", " ", value)).replace("\u200b", "").replace("\ufeff", "")
+    if text.strip():
+        return True
+    return bool(re.search(r"<(?:img|ul|ol|li|table|tr|td|blockquote)\b", value, flags=re.IGNORECASE))
 
-        draft = _merge_message_attachments(draft, msg_data)
 
-        # Validate required fields
-        warnings: list[str] = []
-        to_list = draft.get("to") or []
-        if not to_list:
-            warnings.append("Draft has no recipients (to is empty)")
-        if not (draft.get("subject") or "").strip():
-            warnings.append("Draft has no subject")
-        if not (draft.get("body") or draft.get("htmlBody") or "").strip():
-            warnings.append("Draft has no body")
+def _preflight(
+    thread_id: str,
+    draft_id: str,
+    *,
+    account: str | None = None,
+    sid: str | None = None,
+    require_explicit_account: bool = False,
+    allow_empty_subject: bool = False,
+    attempt_superhuman_id: str | None = None,
+) -> dict[str, Any]:
+    """Authoritative read-only guard used by both validate and execute."""
+    try:
+        state, wrapper, warnings = lifecycle.observe(
+            thread_id,
+            draft_id,
+            account=account,
+            require_explicit_account=require_explicit_account,
+            attempt_superhuman_id=attempt_superhuman_id,
+        )
+    except LookupError as exc:
+        raise SendSafetyError("DRAFT_NOT_FOUND", str(exc), cls="not-found") from exc
+    except lifecycle.AccountBindingError as exc:
+        raise SendSafetyError("ACCOUNT_BINDING_MISMATCH", str(exc), cls="input") from exc
 
-        outgoing = _build_outgoing(draft)
+    state_name = state["state"]
+    if state_name == lifecycle.PROVIDER_CONFIRMED:
+        raise SendSafetyError("DRAFT_ALREADY_SENT", "Draft already has an immutable provider-confirmed sent message")
+    if state_name == lifecycle.BACKEND_CONFIRMED:
+        raise SendSafetyError("DRAFT_ALREADY_SENT", "Draft has a terminal backend send job and cannot be submitted again")
+    if state_name == lifecycle.DISCARDED:
+        raise SendSafetyError("DRAFT_DISCARDED", "Draft has been discarded")
+    if state_name in {lifecycle.SCHEDULED, lifecycle.REQUESTED, lifecycle.PENDING_UNDO}:
+        raise SendSafetyError("SEND_ALREADY_PENDING", f"Draft already has a nonterminal send job ({state_name})")
+    if state_name in {lifecycle.FAILED, lifecycle.ABORTED}:
+        raise SendSafetyError("TERMINAL_SEND_JOB", f"Draft has a terminal send job ({state_name}); create a new draft")
+    if state_name == lifecycle.INCONSISTENT:
+        raise SendSafetyError("LIFECYCLE_INCONSISTENT", "Draft has contradictory send evidence; reconcile it before any send")
+    if state_name != lifecycle.ACTIVE:
+        raise SendSafetyError("DRAFT_NOT_ACTIVE", f"Draft is not active ({state_name})")
 
+    draft = wrapper.get("draft")
+    if not isinstance(draft, dict):
+        raise SendSafetyError("DRAFT_NOT_FOUND", f"Draft {draft_id} not found", cls="not-found")
+    draft = _merge_message_attachments(draft, wrapper)
+
+    recipients = list(draft.get("to") or []) + list(draft.get("cc") or []) + list(draft.get("bcc") or [])
+    if not recipients:
+        raise SendSafetyError("RECIPIENTS_REQUIRED", "Draft has no recipients", cls="input")
+    invalid = [_contact_json(item).get("email", "") for item in recipients if not _valid_address(item)]
+    if invalid:
+        raise SendSafetyError("INVALID_RECIPIENT", "Draft contains an invalid recipient address", cls="input")
+
+    from_email = _contact_json(draft.get("from")).get("email", "").lower()
+    bound_email = str(state["account"]["email"]).lower()
+    if not from_email or from_email != bound_email:
+        raise SendSafetyError(
+            "FROM_ACCOUNT_MISMATCH",
+            f"Draft From address is not the bound account {state['account']['email']}",
+            cls="input",
+        )
+
+    if not _body_has_content(str(draft.get("htmlBody") or draft.get("body") or "")):
+        raise SendSafetyError("BODY_REQUIRED", "Draft body is empty", cls="input")
+    if not allow_empty_subject and not str(draft.get("subject") or "").strip():
+        raise SendSafetyError("SUBJECT_REQUIRED", "Draft subject is empty and has not been explicitly attested", cls="input")
+
+    outgoing = _build_outgoing(draft, sid=sid)
+    return {
+        "thread_id": thread_id,
+        "draft_id": draft_id,
+        "draft": draft,
+        "wrapper": wrapper,
+        "lifecycle": state,
+        "outgoing": outgoing,
+        "warnings": warnings,
+    }
+
+
+def validate(thread_id: str, draft_id: str, *, account: str | None = None) -> dict[str, Any]:
+    """Read-only metadata preflight. Exact render attestation remains required."""
+    try:
+        checked = _preflight(thread_id, draft_id, account=account)
+        draft = checked["draft"]
+        outgoing = checked["outgoing"]
         result: dict[str, Any] = {
             "thread_id": thread_id,
             "draft_id": draft_id,
-            "sendable": len(warnings) == 0 or bool(to_list),
+            "sendable": True,
+            "send_eligible": False,
+            "render_attested": False,
             "action": draft.get("action", "compose"),
             "from": outgoing.get("from"),
             "to": outgoing.get("to"),
             "cc": outgoing.get("cc"),
+            "bcc_count": len(outgoing.get("bcc") or []),
             "subject": outgoing.get("subject"),
             "body_preview": (draft.get("snippet") or "")[:200],
             "has_attachments": bool(outgoing.get("attachments")),
+            "lifecycle": checked["lifecycle"],
+            "next_step": "Create an exact render attestation before --confirm",
         }
-        # Include smart-send fields when set
         for draft_key, result_key in {
             "scheduledFor": "scheduled_for",
             "abortOnReply": "abort_on_reply",
@@ -219,57 +311,333 @@ def validate(thread_id: str, draft_id: str) -> dict[str, Any]:
             val = draft.get(draft_key)
             if val not in (None, [], "", False):
                 result[result_key] = val
-        return ok("send.validate", result, warnings=warnings)
-    except Exception as e:
-        return fail("send.validate", [classify_exception(e)])
+        return ok("send.validate", result, warnings=checked["warnings"])
+    except SendSafetyError as exc:
+        return _safety_failure("send.validate", exc)
+    except Exception as exc:
+        return fail("send.validate", [classify_exception(exc)])
 
 
-def execute(thread_id: str, draft_id: str, *, delay: int = SEND_DELAY_SECONDS) -> dict[str, Any]:
-    """Actually send a draft. THIS IS IRREVERSIBLE.
+def _post_exact_payload(outgoing: dict[str, Any], *, delay: int) -> None:
+    """POST freshly probed exact payload bytes; caller owns idempotent claim."""
+    request_body = {
+        "version": 3,
+        "outgoing_message": outgoing,
+        "delay": delay,
+        "is_multi_recipient": True,
+    }
+    req = urllib.request.Request(
+        "https://mail.superhuman.com/~backend/messages/send",
+        data=_attestation.canonical_bytes(request_body),
+        headers={**_auth.api_headers(), "Content-Type": "application/json; charset=utf-8"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        resp.read()
 
-    The draft must already exist on the thread. Use validate() first.
-    """
-    try:
-        ud = _thread.userdata_raw(thread_id)
-        if not ud:
-            return fail("send", [error("not-found", "THREAD_NOT_FOUND", False, f"No userdata for thread {thread_id}")])
 
-        msgs = ud.get("messages", {})
-        msg_data = msgs.get(draft_id, {})
-        draft = msg_data.get("draft")
-        if not draft:
-            return fail("send", [error("not-found", "DRAFT_NOT_FOUND", False, f"Draft {draft_id} not found")])
+def _attempt_result(attempt: dict[str, Any], state: dict[str, Any], *, accepted: bool) -> dict[str, Any]:
+    provider_confirmed = state["state"] == lifecycle.PROVIDER_CONFIRMED
+    material_state = state["state"]
+    if accepted and material_state == lifecycle.ACTIVE and attempt.get("state") == "unknown":
+        material_state = "unknown"
+    return {
+        "attempt_id": attempt["attempt_id"],
+        "thread_id": attempt["thread_id"],
+        "draft_id": attempt["draft_id"],
+        "attestation_id": attempt["attestation_id"],
+        "state": material_state,
+        "accepted": accepted,
+        "sent": provider_confirmed,
+        "provider_confirmed": provider_confirmed,
+        "outbound_evidence": bool(state["outbound_evidence"]),
+        "superhuman_id": attempt["superhuman_id"],
+        "provider_message_id": (state.get("provider_message") or {}).get("id"),
+        "idempotency_scope": _attempts.IDEMPOTENCY_SCOPE,
+        "lifecycle": state,
+    }
 
-        draft = _merge_message_attachments(draft, msg_data)
 
-        outgoing = _build_outgoing(draft)
-        request_body = {
-            "version": 3,
-            "outgoing_message": outgoing,
-            "delay": delay,
-            "is_multi_recipient": True,
-        }
+def _reconcile(
+    attempt: dict[str, Any],
+    *,
+    account: str,
+    wait: float,
+    journal: _attempts.AttemptJournal,
+    sleep: Any = time.sleep,
+    monotonic: Any = time.monotonic,
+) -> tuple[dict[str, Any], dict[str, Any], list[str]]:
+    """Poll backend/provider evidence without ever creating a new identity."""
+    deadline = monotonic() + max(0.0, wait)
+    interval = 0.25
+    warnings: list[str] = []
+    last_state: dict[str, Any] | None = None
+    last_attempt = attempt
 
-        req = urllib.request.Request(
-            "https://mail.superhuman.com/~backend/messages/send",
-            data=json.dumps(request_body).encode(),
-            headers={**_auth.api_headers(), "Content-Type": "application/json; charset=utf-8"},
-            method="POST",
+    while True:
+        state, _wrapper, observed_warnings = lifecycle.observe(
+            attempt["thread_id"],
+            attempt["draft_id"],
+            account=account,
+            require_explicit_account=True,
+            attempt_superhuman_id=attempt["superhuman_id"],
         )
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            raw = resp.read().decode()
-            try:
-                result = json.loads(raw) if raw else {}
-            except json.JSONDecodeError:
-                result = {}
+        warnings.extend(item for item in observed_warnings if item not in warnings)
+        if (
+            attempt.get("state") == lifecycle.PROVIDER_CONFIRMED
+            and attempt.get("provider_message_id")
+            and state["state"] != lifecycle.PROVIDER_CONFIRMED
+        ):
+            # An immutable provider confirmation already recorded by this
+            # attempt cannot be downgraded by a later stale/empty local cache.
+            preserved = {
+                **state,
+                "state": lifecycle.PROVIDER_CONFIRMED,
+                "terminal": True,
+                "send_blocked": True,
+                "outbound_evidence": True,
+                "confidence": "provider_confirmed_journal",
+                "consistency": "observation_lag",
+                "provider_message": {
+                    **(state.get("provider_message") or {}),
+                    "id": attempt["provider_message_id"],
+                },
+            }
+            warnings.append("Current provider cache lags a previously recorded immutable confirmation")
+            return attempt, preserved, warnings
+        last_state = state
+        update: dict[str, Any] = {"last_reconciled_at": datetime_now_iso()}
+        state_name = state["state"]
+        if state_name == lifecycle.PROVIDER_CONFIRMED:
+            provider = state.get("provider_message") or {}
+            update.update({
+                "provider_message_id": provider.get("id"),
+                "provider_sent_at": state.get("timestamps", {}).get("provider_message_at"),
+            })
+            last_attempt = journal.update(attempt["attempt_id"], state=state_name, **update)
+            return last_attempt, state, warnings
+        if state_name == lifecycle.BACKEND_CONFIRMED:
+            update["backend_sent_at"] = state.get("timestamps", {}).get("sent_at")
+            last_attempt = journal.update(attempt["attempt_id"], state=state_name, **update)
+        elif state_name in {lifecycle.FAILED, lifecycle.ABORTED, lifecycle.SCHEDULED}:
+            last_attempt = journal.update(attempt["attempt_id"], state=state_name, **update)
+            return last_attempt, state, warnings
+        elif state_name == lifecycle.INCONSISTENT:
+            last_attempt = journal.update(attempt["attempt_id"], state="unknown", **update)
+            return last_attempt, state, warnings
+        else:
+            # An active source after a POST claim is an unknown/lagging outcome,
+            # never permission to mint another ID or post again.
+            attempt_state = state_name if state_name != lifecycle.ACTIVE else "unknown"
+            last_attempt = journal.update(attempt["attempt_id"], state=attempt_state, **update)
 
-        return ok("send", {
+        now = monotonic()
+        if now >= deadline:
+            assert last_state is not None
+            return last_attempt, last_state, warnings
+        sleep(min(interval, max(0.0, deadline - now)))
+        interval = min(interval * 2, 5.0)
+
+
+def datetime_now_iso() -> str:
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def status(
+    thread_id: str,
+    draft_id: str,
+    *,
+    account: str,
+    wait: float = 0,
+    journal: _attempts.AttemptJournal | None = None,
+) -> dict[str, Any]:
+    """Reconcile one draft/attempt and return a truthful typed state."""
+    try:
+        identity, warnings = lifecycle.resolve_account(account, require_explicit=True)
+        journal = journal or _attempts.AttemptJournal()
+        attempt = journal.get(identity["provider_user_id"], draft_id)
+        if attempt:
+            updated, state, observed_warnings = _reconcile(
+                attempt,
+                account=identity["email"],
+                wait=wait,
+                journal=journal,
+            )
+            return ok("send.status", _attempt_result(updated, state, accepted=int(updated["post_count"]) > 0), warnings=warnings + observed_warnings)
+        state, _wrapper, observed_warnings = lifecycle.observe(
+            thread_id,
+            draft_id,
+            account=identity["email"],
+            require_explicit_account=True,
+        )
+        return ok("send.status", {
+            "attempt_id": None,
             "thread_id": thread_id,
             "draft_id": draft_id,
-            "delay_seconds": delay,
-            "to": outgoing.get("to"),
-            "subject": outgoing.get("subject"),
-            "sent": True,
-        })
-    except Exception as e:
-        return fail("send", [classify_exception(e)])
+            "state": state["state"],
+            "accepted": False,
+            "sent": state["state"] == lifecycle.PROVIDER_CONFIRMED,
+            "provider_confirmed": state["state"] == lifecycle.PROVIDER_CONFIRMED,
+            "outbound_evidence": state["outbound_evidence"],
+            "idempotency_scope": _attempts.IDEMPOTENCY_SCOPE,
+            "lifecycle": state,
+        }, warnings=warnings + observed_warnings)
+    except Exception as exc:
+        return fail("send.status", [classify_exception(exc)])
+
+
+def execute(
+    thread_id: str,
+    draft_id: str,
+    *,
+    delay: int = SEND_DELAY_SECONDS,
+    account: str | None = None,
+    attestation: str | None = None,
+    approval_ref: str | None = None,
+    wait: float = 120,
+    journal: _attempts.AttemptJournal | None = None,
+    renderer: _attestation.Renderer | None = None,
+) -> dict[str, Any]:
+    """Strict, locally idempotent exact-render send execution.
+
+    The external grace period must finish before this function is invoked.  It
+    performs the mandatory second no-write renderer probe immediately before
+    the one locally claimed POST, then waits for provider confirmation.
+    """
+    try:
+        if not account:
+            raise SendSafetyError("ACCOUNT_REQUIRED", "--account is required for strict send", cls="input")
+        if not attestation:
+            # Even a malformed invocation runs the lifecycle/envelope/body
+            # guard inside execute, closing the terminal-draft resend path.
+            _preflight(
+                thread_id,
+                draft_id,
+                account=account,
+                require_explicit_account=True,
+                allow_empty_subject=True,
+            )
+            raise SendSafetyError("ATTESTATION_REQUIRED", "--attestation is required for strict send", cls="input")
+        if not approval_ref:
+            raise SendSafetyError("APPROVAL_REFERENCE_REQUIRED", "--approval-ref is required for strict send", cls="input")
+        if delay < 0:
+            raise SendSafetyError("INVALID_DELAY", "--delay must be non-negative", cls="input")
+
+        record = _attestation.load(attestation)
+        _attestation.verify(record)
+        if str(record.get("thread_id")) != thread_id or str(record.get("draft_id")) != draft_id:
+            raise SendSafetyError("ATTESTATION_DRAFT_MISMATCH", "Attestation belongs to a different draft/thread")
+        if int(record.get("delay_seconds", -1)) != delay:
+            raise SendSafetyError("ATTESTATION_DELAY_MISMATCH", "Send delay differs from the approved attestation")
+        identity, account_warnings = lifecycle.resolve_account(account, require_explicit=True)
+        if str(record.get("account", {}).get("provider_user_id")) != identity["provider_user_id"]:
+            raise SendSafetyError("ACCOUNT_BINDING_MISMATCH", "Attestation belongs to a different immutable account identity")
+
+        journal = journal or _attempts.AttemptJournal()
+        attempt = journal.get(identity["provider_user_id"], draft_id)
+        if attempt is not None:
+            # Validate that this invocation carries the same approved identity.
+            attempt, _created = journal.create_or_get(
+                account_id=identity["provider_user_id"],
+                account_hash=_attestation.sha256(identity["email"].lower()),
+                thread_id=thread_id,
+                draft_id=draft_id,
+                attestation_id=str(record["attestation_id"]),
+                approval_ref=approval_ref,
+                superhuman_id=str(record["superhuman_id"]),
+                outgoing_fingerprint=str(record["fingerprint"]["exact"]),
+            )
+
+        if attempt is not None and (int(attempt["post_count"]) > 0 or attempt["state"] != "prepared"):
+            updated, state, warnings = _reconcile(
+                attempt,
+                account=identity["email"],
+                wait=wait,
+                journal=journal,
+            )
+            data = _attempt_result(updated, state, accepted=True)
+            if state["state"] in {lifecycle.FAILED, lifecycle.ABORTED, lifecycle.INCONSISTENT}:
+                code = "SEND_TERMINAL_FAILURE" if state["state"] != lifecycle.INCONSISTENT else "LIFECYCLE_INCONSISTENT"
+                return fail("send", [error("conflict", code, False, f"Attempt reconciled to {state['state']}")], warnings=warnings)
+            if not data["sent"] and state["state"] != lifecycle.SCHEDULED:
+                warnings.append("Attempt remains pending/unknown; no additional POST was made")
+            return ok("send", data, warnings=account_warnings + warnings)
+
+        if attempt is None:
+            # New attempts must pass the authoritative execute-time guard.
+            # Existing attempts reconcile even when the source is now pending
+            # or terminal; retry must not be mistaken for a second send.
+            _preflight(
+                thread_id,
+                draft_id,
+                account=identity["email"],
+                require_explicit_account=True,
+                allow_empty_subject=True,
+            )
+
+        # This is the mandatory post-grace, immediately pre-POST exact probe.
+        # Persist the attempt only after this probe succeeds, so a stale or
+        # unavailable renderer never strands the draft behind a no-POST row.
+        verified = _attestation.revalidate_for_send(
+            record,
+            account=identity["email"],
+            renderer=renderer,
+        )
+        if attempt is None:
+            attempt, _created = journal.create_or_get(
+                account_id=identity["provider_user_id"],
+                account_hash=_attestation.sha256(identity["email"].lower()),
+                thread_id=thread_id,
+                draft_id=draft_id,
+                attestation_id=str(record["attestation_id"]),
+                approval_ref=approval_ref,
+                superhuman_id=str(record["superhuman_id"]),
+                outgoing_fingerprint=str(record["fingerprint"]["exact"]),
+            )
+        attempt, claimed = journal.claim_post(attempt["attempt_id"])
+        if not claimed:
+            updated, state, warnings = _reconcile(
+                attempt,
+                account=identity["email"],
+                wait=wait,
+                journal=journal,
+            )
+            return ok("send", _attempt_result(updated, state, accepted=int(updated["post_count"]) > 0), warnings=account_warnings + warnings)
+
+        try:
+            _post_exact_payload(verified["outgoing_payload"], delay=delay)
+            attempt = journal.update(attempt["attempt_id"], state="request_accepted", response_class="http_2xx")
+        except Exception as transport_exc:
+            classified = classify_exception(transport_exc)
+            attempt = journal.update(
+                attempt["attempt_id"],
+                state="unknown",
+                response_class=classified["code"],
+                last_error=f"{type(transport_exc).__name__}",
+            )
+            # A lost response may have followed a successful server accept. Reconcile;
+            # never automatically POST again after the pre-network claim.
+
+        updated, state, warnings = _reconcile(
+            attempt,
+            account=identity["email"],
+            wait=wait,
+            journal=journal,
+        )
+        data = _attempt_result(updated, state, accepted=True)
+        if state["state"] in {lifecycle.FAILED, lifecycle.ABORTED, lifecycle.INCONSISTENT}:
+            code = "SEND_TERMINAL_FAILURE" if state["state"] != lifecycle.INCONSISTENT else "LIFECYCLE_INCONSISTENT"
+            return fail("send", [error("conflict", code, False, f"Attempt reconciled to {state['state']}")], warnings=warnings)
+        if not data["sent"] and state["state"] != lifecycle.SCHEDULED:
+            warnings.append("Request was accepted or outcome is unknown; provider delivery is not yet confirmed")
+        return ok("send", data, warnings=account_warnings + warnings)
+    except SendSafetyError as exc:
+        return _safety_failure("send", exc)
+    except _attestation.AttestationError as exc:
+        return fail("send", [error("conflict", exc.code, False, exc.hint)])
+    except _attempts.AttemptConflict as exc:
+        return fail("send", [error("conflict", "ATTEMPT_CONFLICT", False, str(exc))])
+    except Exception as exc:
+        return fail("send", [classify_exception(exc)])

--- a/superhuman_mail/thread.py
+++ b/superhuman_mail/thread.py
@@ -27,9 +27,20 @@ def read(thread_id: str, account: str | None = None) -> dict[str, Any]:
     return messages(thread_id, account)
 
 
-def userdata(thread_id: str) -> dict[str, Any]:
+def _bind_api_account(account: str | None) -> str:
+    """Bind a userdata request to the one configured private-API identity."""
+    configured = _config.api("email")
+    if account is not None and account.strip().lower() != configured.lower():
+        raise ValueError(
+            f"Account {account} is not bound to configured API identity {configured}"
+        )
+    return configured
+
+
+def userdata(thread_id: str, account: str | None = None) -> dict[str, Any]:
     """Read thread userdata (drafts, comments, metadata) from the API."""
     try:
+        _bind_api_account(account)
         payload = {
             "reads": [{"path": f"users/{_config.api('google_id')}/threads/{thread_id}"}],
             "pageSize": 100,
@@ -49,8 +60,9 @@ def userdata(thread_id: str) -> dict[str, Any]:
         return fail("thread.userdata", [classify_exception(e)])
 
 
-def userdata_raw(thread_id: str) -> dict[str, Any] | None:
+def userdata_raw(thread_id: str, account: str | None = None) -> dict[str, Any] | None:
     """Read thread userdata and return the raw value (no envelope). Used internally."""
+    _bind_api_account(account)
     payload = {
         "reads": [{"path": f"users/{_config.api('google_id')}/threads/{thread_id}"}],
         "pageSize": 100,
@@ -67,9 +79,9 @@ def userdata_raw(thread_id: str) -> dict[str, Any] | None:
     return results[0].get("value") if results else None
 
 
-def current_history_id(thread_id: str) -> int | None:
+def current_history_id(thread_id: str, account: str | None = None) -> int | None:
     """Get the current history ID for a thread (used for optimistic writes)."""
-    ud = userdata_raw(thread_id)
+    ud = userdata_raw(thread_id, account=account)
     if not ud:
         return None
     hid = ud.get("historyId")

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -1,0 +1,302 @@
+"""Externally issued approval receipt authority and exact-binding tests."""
+from __future__ import annotations
+
+import base64
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from superhuman_mail import approval
+
+NOW = datetime(2026, 7, 10, 12, 0, 0, tzinfo=timezone.utc)
+ISSUER = "pinet-slack-approval-fixture"
+KEY_ID = "ed25519:fixture"
+APPROVER = "slack:U-fixture"
+
+
+def _attestation(**overrides):
+    value = {
+        "attestation_id": "sha256:attestation",
+        "account": {"email": "owner@example.test", "provider_user_id": "provider-user-fixture"},
+        "thread_id": "thread-fixture",
+        "draft_id": "draft-fixture",
+        "superhuman_id": "sid.fixture",
+        "delay_seconds": 20,
+        "fingerprint": {"exact": "sha256:fingerprint"},
+        "outgoing_payload": {
+            "from": {"email": "owner@example.test"},
+            "to": [{"email": "recipient@example.test"}],
+            "cc": [],
+            "bcc": [],
+            "subject": "Fixture",
+            "html_body": "<p>Exact body</p>",
+            "attachments": [],
+            "scheduled_for": None,
+            "superhuman_id": "sid.fixture",
+        },
+    }
+    value.update(overrides)
+    return value
+
+
+def _roots(private_key, *, approvers=None):
+    public = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    return {
+        ISSUER: {
+            "key_id": KEY_ID,
+            "public_key": base64.urlsafe_b64encode(public).decode().rstrip("="),
+            "allowed_approvers": approvers or [APPROVER],
+        }
+    }
+
+
+def _receipt(
+    private_key,
+    attestation=None,
+    *,
+    issued_at=NOW,
+    expires_at=None,
+    approver=APPROVER,
+    binding=None,
+    action=approval.ACTION,
+    provider=approval.PROVIDER,
+):
+    attestation = attestation or _attestation()
+    expires_at = expires_at or (issued_at + timedelta(minutes=3))
+    body = {
+        "schema": approval.SCHEMA,
+        "issuer": ISSUER,
+        "key_id": KEY_ID,
+        "issued_at": issued_at.isoformat().replace("+00:00", "Z"),
+        "expires_at": expires_at.isoformat().replace("+00:00", "Z"),
+        "nonce": "nonce-fixture-0123456789",
+        "approver": {
+            "principal": approver,
+            "approval_event_id": "slack-event-fixture",
+        },
+        "action": action,
+        "provider": provider,
+        "binding": binding or approval.binding_for_attestation(attestation),
+    }
+    receipt_id = approval.sha256(approval.canonical_bytes(body))
+    signed = {**body, "receipt_id": receipt_id}
+    signature = private_key.sign(approval.canonical_bytes(signed))
+    return {
+        **signed,
+        "signature": "ed25519:" + base64.urlsafe_b64encode(signature).decode().rstrip("="),
+    }
+
+
+def test_valid_external_receipt_verifies_exact_binding():
+    private = Ed25519PrivateKey.generate()
+    attestation = _attestation()
+    result = approval.verify(
+        _receipt(private, attestation),
+        attestation=attestation,
+        roots=_roots(private),
+        now=NOW + timedelta(seconds=1),
+    )
+    assert result["authority"] == approval.AUTHORITY
+    assert result["verified"] is True
+    assert result["issuer"] == ISSUER
+    assert result["approver"] == APPROVER
+    assert result["binding"] == approval.binding_for_attestation(attestation)
+
+
+def test_forged_signature_fails_against_pinned_public_key():
+    trusted = Ed25519PrivateKey.generate()
+    attacker = Ed25519PrivateKey.generate()
+    with pytest.raises(approval.ApprovalError) as caught:
+        approval.verify(
+            _receipt(attacker),
+            attestation=_attestation(),
+            roots=_roots(trusted),
+            now=NOW + timedelta(seconds=1),
+        )
+    assert caught.value.code == "APPROVAL_RECEIPT_FORGED"
+
+
+@pytest.mark.parametrize(
+    "attestation",
+    [
+        _attestation(thread_id="wrong-thread"),
+        _attestation(draft_id="wrong-draft"),
+        _attestation(delay_seconds=99),
+        _attestation(superhuman_id="wrong-sid"),
+        _attestation(account={"email": "other@example.test", "provider_user_id": "other-user"}),
+        _attestation(outgoing_payload={**_attestation()["outgoing_payload"], "to": [{"email": "other@example.test"}]}),
+        _attestation(outgoing_payload={**_attestation()["outgoing_payload"], "html_body": "<p>changed</p>"}),
+    ],
+)
+def test_signed_receipt_cannot_authorize_mismatched_exact_send(attestation):
+    private = Ed25519PrivateKey.generate()
+    receipt = _receipt(private, _attestation())
+    with pytest.raises(approval.ApprovalError) as caught:
+        approval.verify(
+            receipt,
+            attestation=attestation,
+            roots=_roots(private),
+            now=NOW + timedelta(seconds=1),
+        )
+    assert caught.value.code == "APPROVAL_BINDING_MISMATCH"
+
+
+def test_tampered_signed_field_fails_canonical_receipt_identity():
+    private = Ed25519PrivateKey.generate()
+    receipt = _receipt(private)
+    receipt["binding"] = {**receipt["binding"], "delay_seconds": 99}
+    with pytest.raises(approval.ApprovalError) as caught:
+        approval.verify(receipt, attestation=_attestation(), roots=_roots(private), now=NOW)
+    assert caught.value.code == "APPROVAL_RECEIPT_TAMPERED"
+
+
+@pytest.mark.parametrize(
+    ("issued_at", "expires_at", "code"),
+    [
+        (NOW - timedelta(minutes=4), NOW - timedelta(seconds=1), "APPROVAL_RECEIPT_EXPIRED"),
+        (NOW + timedelta(minutes=1), NOW + timedelta(minutes=2), "APPROVAL_RECEIPT_NOT_YET_VALID"),
+        (NOW, NOW + timedelta(minutes=6), "APPROVAL_RECEIPT_INVALID"),
+    ],
+)
+def test_receipt_lifetime_fails_closed(issued_at, expires_at, code):
+    private = Ed25519PrivateKey.generate()
+    with pytest.raises(approval.ApprovalError) as caught:
+        approval.verify(
+            _receipt(private, issued_at=issued_at, expires_at=expires_at),
+            attestation=_attestation(),
+            roots=_roots(private),
+            now=NOW,
+        )
+    assert caught.value.code == code
+
+
+@pytest.mark.parametrize(
+    ("overrides", "code"),
+    [
+        ({"action": "other.send"}, "APPROVAL_ACTION_MISMATCH"),
+        ({"provider": "other"}, "APPROVAL_ACTION_MISMATCH"),
+    ],
+)
+def test_signed_receipt_for_other_action_or_provider_is_rejected(overrides, code):
+    private = Ed25519PrivateKey.generate()
+    with pytest.raises(approval.ApprovalError) as caught:
+        approval.verify(
+            _receipt(private, **overrides),
+            attestation=_attestation(),
+            roots=_roots(private),
+            now=NOW,
+        )
+    assert caught.value.code == code
+
+
+def test_unknown_or_wrong_key_id_is_rejected_before_signature_trust():
+    private = Ed25519PrivateKey.generate()
+    roots = _roots(private)
+    roots[ISSUER]["key_id"] = "different-key"
+    with pytest.raises(approval.ApprovalError) as caught:
+        approval.verify(
+            _receipt(private),
+            attestation=_attestation(),
+            roots=roots,
+            now=NOW,
+        )
+    assert caught.value.code == "APPROVAL_ISSUER_UNTRUSTED"
+
+
+def test_signed_but_unauthorized_approver_is_rejected():
+    private = Ed25519PrivateKey.generate()
+    with pytest.raises(approval.ApprovalError) as caught:
+        approval.verify(
+            _receipt(private, approver="slack:attacker"),
+            attestation=_attestation(),
+            roots=_roots(private),
+            now=NOW,
+        )
+    assert caught.value.code == "APPROVER_UNAUTHORIZED"
+
+
+def test_no_pinned_external_issuer_disables_strict_send(monkeypatch):
+    monkeypatch.setattr(approval, "BUILTIN_TRUST_ROOTS", {})
+    monkeypatch.setattr(approval, "TRUST_STORE_PATH", Path("/nonexistent/trust.json"))
+    with pytest.raises(approval.ApprovalError) as caught:
+        approval.trusted_issuers()
+    assert caught.value.code == "APPROVAL_TRUST_UNAVAILABLE"
+
+
+def test_user_writable_trust_store_path_is_rejected(monkeypatch, tmp_path):
+    trust = tmp_path / "approval-trust-v1.json"
+    trust.write_text('{"schema":"shm-approval-trust/v1","issuers":{}}')
+    monkeypatch.setattr(approval, "TRUST_STORE_PATH", trust)
+    with pytest.raises(approval.ApprovalError) as caught:
+        approval._read_system_trust_store()
+    assert caught.value.code == "APPROVAL_TRUST_UNSAFE"
+
+
+def test_caller_environment_cannot_install_approval_root(monkeypatch):
+    monkeypatch.setenv("SHM_APPROVAL_PUBLIC_KEY", "attacker-controlled")
+    monkeypatch.setattr(approval, "BUILTIN_TRUST_ROOTS", {})
+    monkeypatch.setattr(approval, "TRUST_STORE_PATH", Path("/nonexistent/trust.json"))
+    with pytest.raises(approval.ApprovalError) as caught:
+        approval.trusted_issuers()
+    assert caught.value.code == "APPROVAL_TRUST_UNAVAILABLE"
+
+
+def test_safe_verify_surface_reports_authority_and_unconsumed_state():
+    attestation = _attestation()
+    verified = {
+        "receipt_id": "sha256:" + "a" * 64,
+        "receipt_digest": "sha256:" + "b" * 64,
+        "issuer": ISSUER,
+        "key_id": KEY_ID,
+        "approver": APPROVER,
+        "approval_event_id": "event-fixture",
+        "issued_at": "2026-07-10T12:00:00Z",
+        "expires_at": "2026-07-10T12:03:00Z",
+        "expired": False,
+        "binding": approval.binding_for_attestation(attestation),
+    }
+
+    class Journal:
+        def get_receipt_consumption(self, _receipt_id):
+            return None
+
+    with patch("superhuman_mail.attestation.load", return_value=attestation):
+        with patch("superhuman_mail.attestation.verify"):
+            with patch("superhuman_mail.approval.load", return_value={"receipt": "fixture"}):
+                with patch("superhuman_mail.approval.verify", return_value=verified):
+                    result = approval.show_safe(
+                        "receipt.json",
+                        attestation_reference="attestation-fixture",
+                        journal=Journal(),
+                    )
+    assert result["authority"] == approval.AUTHORITY
+    assert result["verified"] is True
+    assert result["usable"] is True
+    assert result["consumed"] is False
+    assert result["unattended_send_eligible"] is False
+    assert result["trusted_executor_required"] is True
+    assert "event-fixture" not in str(result)
+
+
+def test_published_json_schema_binding_matches_core_contract():
+    schema = json.loads((Path(__file__).parents[1] / "docs" / "approval-receipt-v1.schema.json").read_text())
+    required = set(schema["properties"]["binding"]["required"])
+    assert required == set(approval.binding_for_attestation(_attestation()))
+
+
+def test_receipt_binding_contains_hashes_not_mail_content():
+    binding = approval.binding_for_attestation(_attestation())
+    serialized = str(binding)
+    assert "recipient@example.test" not in serialized
+    assert "Exact body" not in serialized
+    assert binding["action"] == approval.ACTION
+    assert binding["provider"] == approval.PROVIDER
+    assert binding["outgoing_payload_sha256"].startswith("sha256:")

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -211,6 +211,20 @@ def test_unknown_or_wrong_key_id_is_rejected_before_signature_trust():
     assert caught.value.code == "APPROVAL_ISSUER_UNTRUSTED"
 
 
+def test_malformed_allowed_approver_configuration_fails_closed():
+    private = Ed25519PrivateKey.generate()
+    roots = _roots(private)
+    roots[ISSUER]["allowed_approvers"] = APPROVER
+    with pytest.raises(approval.ApprovalError) as caught:
+        approval.verify(
+            _receipt(private),
+            attestation=_attestation(),
+            roots=roots,
+            now=NOW,
+        )
+    assert caught.value.code == "APPROVAL_TRUST_UNAVAILABLE"
+
+
 def test_signed_but_unauthorized_approver_is_rejected():
     private = Ed25519PrivateKey.generate()
     with pytest.raises(approval.ApprovalError) as caught:

--- a/tests/test_attempts.py
+++ b/tests/test_attempts.py
@@ -6,7 +6,12 @@ import stat
 
 import pytest
 
-from superhuman_mail.attempts import AttemptConflict, AttemptJournal, IDEMPOTENCY_SCOPE
+from superhuman_mail.attempts import (
+    AttemptConflict,
+    AttemptJournal,
+    IDEMPOTENCY_SCOPE,
+    ReceiptClaimError,
+)
 
 
 def _create(journal: AttemptJournal, **overrides):
@@ -16,12 +21,28 @@ def _create(journal: AttemptJournal, **overrides):
         "thread_id": "thread-fixture",
         "draft_id": "draft-fixture",
         "attestation_id": "attestation-fixture",
-        "approval_ref": "approval-fixture",
+        "approval_receipt_id": "sha256:receipt-fixture",
+        "approval_receipt_digest": "sha256:receipt-digest",
+        "approval_issuer": "issuer-fixture",
+        "approval_key_id": "key-fixture",
+        "approval_approver": "slack:user-fixture",
+        "approval_issued_at": "2026-07-10T12:00:00Z",
+        "approval_expires_at": "2099-07-10T12:05:00Z",
         "superhuman_id": "sid.fixture",
         "outgoing_fingerprint": "sha256:payload",
     }
     kwargs.update(overrides)
     return journal.create_or_get(**kwargs)
+
+
+def _claim(journal: AttemptJournal, attempt_id: str, **overrides):
+    kwargs = {
+        "approval_receipt_id": "sha256:receipt-fixture",
+        "approval_receipt_digest": "sha256:receipt-digest",
+        "approval_expires_at": "2099-07-10T12:05:00Z",
+    }
+    kwargs.update(overrides)
+    return journal.claim_post(attempt_id, **kwargs)
 
 
 def test_create_or_get_reuses_one_attempt_identity(tmp_path):
@@ -42,7 +63,8 @@ def test_unclaimed_prepared_attempt_can_rotate_to_fresh_attestation(tmp_path):
     replacement, created = _create(
         journal,
         attestation_id="attestation-fresh",
-        approval_ref="approval-fresh",
+        approval_receipt_id="sha256:receipt-fresh",
+        approval_receipt_digest="sha256:receipt-digest-fresh",
         superhuman_id="sid.fresh",
         outgoing_fingerprint="sha256:fresh",
     )
@@ -55,7 +77,7 @@ def test_unclaimed_prepared_attempt_can_rotate_to_fresh_attestation(tmp_path):
 def test_claimed_attempt_rejects_new_identity_or_payload(tmp_path):
     journal = AttemptJournal(tmp_path / "attempts.sqlite3")
     attempt, _ = _create(journal)
-    journal.claim_post(attempt["attempt_id"])
+    _claim(journal, attempt["attempt_id"])
     with pytest.raises(AttemptConflict, match="superhuman_id"):
         _create(journal, superhuman_id="sid.different")
     with pytest.raises(AttemptConflict, match="outgoing_fingerprint"):
@@ -68,7 +90,7 @@ def test_atomic_claim_allows_exactly_one_local_poster(tmp_path):
 
     def claim():
         local = AttemptJournal(journal.path)
-        row, won = local.claim_post(attempt["attempt_id"])
+        row, won = _claim(local, attempt["attempt_id"])
         return row["attempt_id"], won
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
@@ -82,19 +104,81 @@ def test_atomic_claim_allows_exactly_one_local_poster(tmp_path):
 def test_post_claim_is_not_automatically_reopened_after_unknown_outcome(tmp_path):
     journal = AttemptJournal(tmp_path / "attempts.sqlite3")
     attempt, _ = _create(journal)
-    _row, won = journal.claim_post(attempt["attempt_id"])
+    _row, won = _claim(journal, attempt["attempt_id"])
     assert won is True
     journal.update(attempt["attempt_id"], state="unknown", last_error="connection reset")
-    _row, won_again = journal.claim_post(attempt["attempt_id"])
+    _row, won_again = _claim(journal, attempt["attempt_id"])
     assert won_again is False
     assert journal.get_by_id(attempt["attempt_id"])["post_count"] == 1
 
 
-def test_journal_does_not_store_raw_approval_reference(tmp_path):
+def test_journal_stores_receipt_audit_identity_not_approval_message_text(tmp_path):
     journal = AttemptJournal(tmp_path / "attempts.sqlite3")
-    attempt, _ = _create(journal, approval_ref="private approval text")
+    attempt, _ = _create(journal)
     assert attempt["approval_ref_hash"].startswith("sha256:")
+    assert attempt["approval_receipt_id"] == "sha256:receipt-fixture"
     assert "private approval text" not in str(attempt)
+
+
+def test_receipt_consume_and_post_claim_are_one_atomic_transaction(tmp_path):
+    journal = AttemptJournal(tmp_path / "attempts.sqlite3")
+    attempt, _ = _create(journal)
+    row, won = _claim(journal, attempt["attempt_id"])
+    consumption = journal.get_receipt_consumption("sha256:receipt-fixture")
+    assert won is True
+    assert row["post_count"] == 1
+    assert consumption["attempt_id"] == attempt["attempt_id"]
+    assert consumption["receipt_digest"] == "sha256:receipt-digest"
+
+
+def test_receipt_replay_on_another_attempt_is_rejected(tmp_path):
+    journal = AttemptJournal(tmp_path / "attempts.sqlite3")
+    first, _ = _create(journal)
+    _claim(journal, first["attempt_id"])
+    second, _ = _create(journal, draft_id="draft-other")
+    with pytest.raises(ReceiptClaimError) as caught:
+        _claim(journal, second["attempt_id"])
+    assert caught.value.code == "APPROVAL_RECEIPT_REPLAYED"
+    assert journal.get_by_id(second["attempt_id"])["post_count"] == 0
+
+
+def test_receipt_expiry_is_rechecked_inside_atomic_claim(tmp_path):
+    journal = AttemptJournal(tmp_path / "attempts.sqlite3")
+    attempt, _ = _create(journal, approval_expires_at="2000-01-01T00:00:00Z")
+    with pytest.raises(ReceiptClaimError) as caught:
+        _claim(
+            journal,
+            attempt["attempt_id"],
+            approval_expires_at="2000-01-01T00:00:00Z",
+        )
+    assert caught.value.code == "APPROVAL_RECEIPT_EXPIRED"
+    assert journal.get_receipt_consumption("sha256:receipt-fixture") is None
+    assert journal.get_by_id(attempt["attempt_id"])["post_count"] == 0
+
+
+def test_provider_confirmed_dedupe_tombstone_is_never_purged(tmp_path):
+    path = tmp_path / "attempts.sqlite3"
+    journal = AttemptJournal(path)
+    attempt, _ = _create(journal)
+    _claim(journal, attempt["attempt_id"])
+    journal.update(
+        attempt["attempt_id"],
+        state="sent_provider_confirmed",
+        provider_message_id="message-fixture",
+    )
+    conn = journal._connect()
+    try:
+        conn.execute(
+            "UPDATE attempts SET updated_at = '2000-01-01T00:00:00Z' WHERE attempt_id = ?",
+            (attempt["attempt_id"],),
+        )
+    finally:
+        conn.close()
+    reopened = AttemptJournal(path)
+    tombstone = reopened.get("user-fixture", "draft-fixture")
+    assert tombstone["attempt_id"] == attempt["attempt_id"]
+    assert tombstone["state"] == "sent_provider_confirmed"
+    assert reopened.purge_terminal(retention_days=0) == 0
 
 
 def test_retention_never_purges_future_scheduled_attempts(tmp_path):

--- a/tests/test_attempts.py
+++ b/tests/test_attempts.py
@@ -1,0 +1,122 @@
+"""Local attempt identity, locking, and retry-safety tests."""
+from __future__ import annotations
+
+import concurrent.futures
+import stat
+
+import pytest
+
+from superhuman_mail.attempts import AttemptConflict, AttemptJournal, IDEMPOTENCY_SCOPE
+
+
+def _create(journal: AttemptJournal, **overrides):
+    kwargs = {
+        "account_id": "user-fixture",
+        "account_hash": "hmac:account",
+        "thread_id": "thread-fixture",
+        "draft_id": "draft-fixture",
+        "attestation_id": "attestation-fixture",
+        "approval_ref": "approval-fixture",
+        "superhuman_id": "sid.fixture",
+        "outgoing_fingerprint": "sha256:payload",
+    }
+    kwargs.update(overrides)
+    return journal.create_or_get(**kwargs)
+
+
+def test_create_or_get_reuses_one_attempt_identity(tmp_path):
+    journal = AttemptJournal(tmp_path / "attempts.sqlite3")
+    first, created = _create(journal)
+    second, created_again = _create(journal)
+    assert created is True
+    assert created_again is False
+    assert first["attempt_id"] == second["attempt_id"]
+    assert first["superhuman_id"] == second["superhuman_id"] == "sid.fixture"
+    assert first["post_count"] == 0
+    assert IDEMPOTENCY_SCOPE == "local_cooperating_processes"
+
+
+def test_unclaimed_prepared_attempt_can_rotate_to_fresh_attestation(tmp_path):
+    journal = AttemptJournal(tmp_path / "attempts.sqlite3")
+    original, _ = _create(journal)
+    replacement, created = _create(
+        journal,
+        attestation_id="attestation-fresh",
+        approval_ref="approval-fresh",
+        superhuman_id="sid.fresh",
+        outgoing_fingerprint="sha256:fresh",
+    )
+    assert created is True
+    assert replacement["attempt_id"] != original["attempt_id"]
+    assert replacement["post_count"] == 0
+    assert journal.get_by_id(original["attempt_id"]) is None
+
+
+def test_claimed_attempt_rejects_new_identity_or_payload(tmp_path):
+    journal = AttemptJournal(tmp_path / "attempts.sqlite3")
+    attempt, _ = _create(journal)
+    journal.claim_post(attempt["attempt_id"])
+    with pytest.raises(AttemptConflict, match="superhuman_id"):
+        _create(journal, superhuman_id="sid.different")
+    with pytest.raises(AttemptConflict, match="outgoing_fingerprint"):
+        _create(journal, outgoing_fingerprint="sha256:different")
+
+
+def test_atomic_claim_allows_exactly_one_local_poster(tmp_path):
+    journal = AttemptJournal(tmp_path / "attempts.sqlite3")
+    attempt, _ = _create(journal)
+
+    def claim():
+        local = AttemptJournal(journal.path)
+        row, won = local.claim_post(attempt["attempt_id"])
+        return row["attempt_id"], won
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(lambda _index: claim(), range(16)))
+    assert sum(int(won) for _attempt_id, won in results) == 1
+    stored = journal.get_by_id(attempt["attempt_id"])
+    assert stored["state"] == "posting"
+    assert stored["post_count"] == 1
+
+
+def test_post_claim_is_not_automatically_reopened_after_unknown_outcome(tmp_path):
+    journal = AttemptJournal(tmp_path / "attempts.sqlite3")
+    attempt, _ = _create(journal)
+    _row, won = journal.claim_post(attempt["attempt_id"])
+    assert won is True
+    journal.update(attempt["attempt_id"], state="unknown", last_error="connection reset")
+    _row, won_again = journal.claim_post(attempt["attempt_id"])
+    assert won_again is False
+    assert journal.get_by_id(attempt["attempt_id"])["post_count"] == 1
+
+
+def test_journal_does_not_store_raw_approval_reference(tmp_path):
+    journal = AttemptJournal(tmp_path / "attempts.sqlite3")
+    attempt, _ = _create(journal, approval_ref="private approval text")
+    assert attempt["approval_ref_hash"].startswith("sha256:")
+    assert "private approval text" not in str(attempt)
+
+
+def test_retention_never_purges_future_scheduled_attempts(tmp_path):
+    journal = AttemptJournal(tmp_path / "attempts.sqlite3")
+    attempt, _ = _create(journal)
+    journal.update(attempt["attempt_id"], state="scheduled")
+    conn = journal._connect()
+    try:
+        conn.execute(
+            "UPDATE attempts SET updated_at = '2000-01-01T00:00:00Z' WHERE attempt_id = ?",
+            (attempt["attempt_id"],),
+        )
+    finally:
+        conn.close()
+    assert journal.purge_terminal(retention_days=30) == 0
+    assert journal.get_by_id(attempt["attempt_id"])["state"] == "scheduled"
+
+
+def test_state_directory_and_database_are_private(tmp_path):
+    state = tmp_path / "state"
+    state.mkdir(mode=0o755)
+    journal = AttemptJournal(state / "attempts.sqlite3")
+    _create(journal)
+    assert stat.S_IMODE(state.stat().st_mode) == 0o700
+    assert stat.S_IMODE(journal.path.stat().st_mode) == 0o600

--- a/tests/test_attestation.py
+++ b/tests/test_attestation.py
@@ -171,7 +171,8 @@ def test_bundled_renderer_policy_aborts_write_before_dispatch():
     assert [item["disposition"] for item in decisions] == ["continue", "fail", "fail"]
     source = script.read_text()
     assert 'this.send("Fetch.failRequest"' in source
-    assert source.index('client.send("Fetch.enable"') < source.index('client.send("Page.bringToFront"')
+    assert 'client.send("Page.bringToFront"' not in source
+    assert "probe will not focus or navigate" in source
 
 
 def test_probe_network_policy_fails_closed_on_unknown_non_idempotent_requests():

--- a/tests/test_attestation.py
+++ b/tests/test_attestation.py
@@ -1,0 +1,290 @@
+"""Exact render attestation, signing, and stale-check tests."""
+from __future__ import annotations
+
+import base64
+import copy
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from superhuman_mail import attestation, lifecycle
+
+THREAD = "thread_fixture"
+DRAFT = "draft_fixture"
+SID = "sid.fixture"
+ACCOUNT = {"email": "owner@example.test", "provider_user_id": "user-fixture"}
+VERSION = "fixture-version"
+
+
+def _draft(**overrides):
+    value = {
+        "id": DRAFT,
+        "threadId": THREAD,
+        "action": "reply",
+        "from": {"email": ACCOUNT["email"], "name": "Owner"},
+        "to": [{"email": "recipient@example.test", "name": "Recipient"}],
+        "cc": [],
+        "bcc": [],
+        "subject": "Fixture",
+        "body": "<div>Hello</div>",
+        "quotedContent": "<div>Earlier</div>",
+        "quotedContentInlined": False,
+        "inReplyTo": "message_earlier",
+        "inReplyToRfc822Id": "<earlier@example.test>",
+        "references": ["<earlier@example.test>"],
+        "rfc822Id": "<draft@example.test>",
+        "attachments": [],
+    }
+    value.update(overrides)
+    return value
+
+
+def _preflight(draft=None, *, history=42):
+    value = draft or _draft()
+    return {
+        "thread_id": THREAD,
+        "draft_id": DRAFT,
+        "draft": value,
+        "wrapper": {"draft": value},
+        "outgoing": {},
+        "warnings": [],
+        "lifecycle": {
+            "account": ACCOUNT,
+            "state": lifecycle.ACTIVE,
+            "observations": [{"source": "superhuman_userdata_api", "history_id": history}],
+        },
+    }
+
+
+def _payload(html="<div>Hello</div><br><div>Signature</div>"):
+    return {
+        "headers": [
+            {"name": "X-Mailer", "value": f"Superhuman Desktop ({VERSION})"},
+            {"name": "X-Superhuman-ID", "value": SID},
+            {"name": "X-Superhuman-Draft-ID", "value": DRAFT},
+        ],
+        "superhuman_id": SID,
+        "rfc822_id": "<draft@example.test>",
+        "thread_id": THREAD,
+        "message_id": DRAFT,
+        "in_reply_to": "message_earlier",
+        "from": {"email": ACCOUNT["email"], "name": "Owner"},
+        "to": [{"email": "recipient@example.test", "name": "Recipient"}],
+        "cc": [],
+        "bcc": [],
+        "subject": "Fixture",
+        "html_body": html,
+        "attachments": [],
+    }
+
+
+class FakeRenderer:
+    def __init__(self, *, draft=None, payload=None, version=VERSION, dirty=False, events=None):
+        self.draft = draft or _draft()
+        self.payload = payload or _payload()
+        self.version = version
+        self.dirty = dirty
+        self.events = events or []
+        self.calls = []
+
+    def probe(self, request, *, output_dir: Path):
+        self.calls.append(copy.deepcopy(request))
+        output_dir.mkdir(parents=True, exist_ok=True)
+        compose = output_dir / "compose.png"
+        outgoing = output_dir / "outgoing.png"
+        compose.write_bytes(b"compose")
+        outgoing.write_bytes(b"outgoing")
+        return {
+            "account_email": ACCOUNT["email"],
+            "thread_id": THREAD,
+            "draft_id": DRAFT,
+            "dirty": self.dirty,
+            "live_draft_json": copy.deepcopy(self.draft),
+            "editor_html": "<div>Hello</div>",
+            "outgoing_payload": copy.deepcopy(self.payload),
+            "signature_settings": {"signature_id": "signature-fixture"},
+            "app_version": "1041.0.15",
+            "web_version": self.version,
+            "surface": "superhuman-desktop",
+            "network_events": copy.deepcopy(self.events),
+            "screenshots": [str(compose), str(outgoing)],
+        }
+
+
+@pytest.fixture(autouse=True)
+def _key_and_version(monkeypatch, tmp_path):
+    monkeypatch.setenv("SHM_ATTESTATION_KEY", base64.urlsafe_b64encode(b"k" * 32).decode())
+    monkeypatch.setenv("SHM_RENDERER_ALLOW_VERSIONS", VERSION)
+    monkeypatch.setenv("SHM_STATE_DIR", str(tmp_path / "state"))
+
+
+def _create(tmp_path, renderer=None):
+    renderer = renderer or FakeRenderer()
+    with patch("superhuman_mail.send._superhuman_id", return_value=SID):
+        with patch("superhuman_mail.send._preflight", side_effect=[_preflight(), _preflight()]):
+            return attestation.create(
+                THREAD,
+                DRAFT,
+                account=ACCOUNT["email"],
+                output_dir=tmp_path / "preview",
+                renderer=renderer,
+            )
+
+
+def test_create_binds_exact_source_editor_payload_versions_and_screenshots(tmp_path):
+    renderer = FakeRenderer()
+    record = _create(tmp_path, renderer)
+    assert record["send_eligible"] is True
+    assert record["confidence"] == "exact_superhuman_renderer"
+    assert record["superhuman_id"] == SID
+    assert record["fingerprint"]["fields"]["outgoing_payload"] == attestation.sha256(
+        attestation.canonical_bytes(_payload())
+    )
+    assert len(record["screenshots"]) == 2
+    assert renderer.calls[0]["superhuman_id"] == SID
+    attestation.verify(record)
+    loaded = attestation.load(record["attestation_id"])
+    assert loaded["attestation_id"] == record["attestation_id"]
+
+
+def test_safe_show_verifies_binding_and_redacts_all_mail_content(tmp_path):
+    record = _create(tmp_path)
+    summary = attestation.show_safe(
+        record["attestation_id"],
+        account=ACCOUNT["email"],
+        thread_id=THREAD,
+        draft_id=DRAFT,
+    )
+    assert summary["signature_valid"] is True
+    assert summary["usable"] is True
+    assert summary["binding_match"] is True
+    assert summary["summary"] == {
+        "to_count": 1,
+        "cc_count": 0,
+        "bcc_count": 0,
+        "attachment_count": 0,
+        "empty_subject": False,
+        "scheduled": False,
+        "has_quote": True,
+    }
+    serialized = str(summary)
+    assert "Hello" not in serialized
+    assert "recipient@example.test" not in serialized
+    assert "Fixture" not in serialized
+    assert ACCOUNT["provider_user_id"] not in serialized
+    assert SID not in serialized
+
+    with pytest.raises(attestation.AttestationError) as caught:
+        attestation.show_safe(record["attestation_id"], draft_id="draft_other")
+    assert caught.value.code == "ATTESTATION_BINDING_MISMATCH"
+
+
+def test_safe_show_reports_valid_but_expired_as_unusable(tmp_path):
+    record = _create(tmp_path)
+    expired = copy.deepcopy(record)
+    expired["expires_at"] = (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat()
+    expired = attestation._seal(attestation._unsigned(expired))
+    attestation.save(expired)
+    summary = attestation.show_safe(expired["attestation_id"])
+    assert summary["signature_valid"] is True
+    assert summary["expired"] is True
+    assert summary["usable"] is False
+
+
+def test_tampered_or_expired_attestation_is_rejected(tmp_path):
+    record = _create(tmp_path)
+    tampered = copy.deepcopy(record)
+    tampered["outgoing_payload"]["subject"] = "Changed"
+    with pytest.raises(attestation.AttestationError, match="canonical content"):
+        attestation.verify(tampered)
+
+    expired = copy.deepcopy(record)
+    expired["expires_at"] = (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat()
+    # Re-seal to isolate expiry behavior.
+    expired = attestation._seal(attestation._unsigned(expired))
+    with pytest.raises(attestation.AttestationError, match="expired"):
+        attestation.verify(expired)
+
+
+def test_dirty_renderer_version_mismatch_and_write_event_fail_closed(tmp_path):
+    cases = [
+        (FakeRenderer(dirty=True), "DIRTY_RENDERER_DRAFT"),
+        (FakeRenderer(version="new-unreviewed-version"), "RENDERER_VERSION_UNSUPPORTED"),
+        (FakeRenderer(events=[{"method": "POST", "url": "https://mail.superhuman.com/~backend/messages/send"}]), "RENDERER_WROTE_LIVE_STATE"),
+    ]
+    for index, (renderer, code) in enumerate(cases):
+        with patch("superhuman_mail.send._superhuman_id", return_value=SID):
+            with patch("superhuman_mail.send._preflight", return_value=_preflight()):
+                with pytest.raises(attestation.AttestationError) as caught:
+                    attestation.create(
+                        THREAD,
+                        DRAFT,
+                        account=ACCOUNT["email"],
+                        output_dir=tmp_path / f"case-{index}",
+                        renderer=renderer,
+                    )
+        assert caught.value.code == code
+
+
+def test_unreadable_attachment_is_not_send_eligible(tmp_path):
+    attached = _draft(attachments=[{
+        "uuid": "attachment-fixture",
+        "name": "file.pdf",
+        "type": "application/pdf",
+        "size": 10,
+        "source": {"type": "remote-without-digest"},
+    }])
+    with patch("superhuman_mail.send._superhuman_id", return_value=SID):
+        with patch("superhuman_mail.send._preflight", return_value=_preflight(attached)):
+            with pytest.raises(attestation.AttestationError) as caught:
+                attestation.create(
+                    THREAD,
+                    DRAFT,
+                    account=ACCOUNT["email"],
+                    output_dir=tmp_path / "attachment",
+                    renderer=FakeRenderer(draft=attached),
+                )
+    assert caught.value.code == "UNATTESTABLE_ATTACHMENT"
+
+
+def test_send_time_second_probe_returns_fresh_exact_payload(tmp_path):
+    record = _create(tmp_path)
+    renderer = FakeRenderer()
+    with patch("superhuman_mail.send._preflight", side_effect=[_preflight(), _preflight()]):
+        verified = attestation.revalidate_for_send(
+            record,
+            account=ACCOUNT["email"],
+            renderer=renderer,
+            output_dir=tmp_path / "send-time",
+        )
+    assert verified["outgoing_payload"] == _payload()
+    assert verified["outgoing_payload_bytes"] == attestation.canonical_bytes(_payload())
+    assert renderer.calls[0]["superhuman_id"] == SID
+
+
+def test_stale_source_blocks_before_second_probe(tmp_path):
+    record = _create(tmp_path)
+    changed = _preflight(_draft(to=[{"email": "different@example.test"}]))
+    renderer = FakeRenderer()
+    with patch("superhuman_mail.send._preflight", return_value=changed):
+        with pytest.raises(attestation.AttestationError) as caught:
+            attestation.revalidate_for_send(record, account=ACCOUNT["email"], renderer=renderer)
+    assert caught.value.code == "STALE_ATTESTATION"
+    assert renderer.calls == []
+
+
+def test_renderer_payload_drift_after_approval_blocks(tmp_path):
+    record = _create(tmp_path)
+    renderer = FakeRenderer(payload=_payload(html="<div>Changed transport bytes</div>"))
+    with patch("superhuman_mail.send._preflight", side_effect=[_preflight(), _preflight()]):
+        with pytest.raises(attestation.AttestationError) as caught:
+            attestation.revalidate_for_send(
+                record,
+                account=ACCOUNT["email"],
+                renderer=renderer,
+                output_dir=tmp_path / "drift",
+            )
+    assert caught.value.code == "STALE_ATTESTATION"
+    assert "outgoing_payload" in caught.value.hint

--- a/tests/test_attestation.py
+++ b/tests/test_attestation.py
@@ -133,6 +133,13 @@ def _create(tmp_path, renderer=None):
             )
 
 
+def test_production_allowlist_binds_app_and_web_versions(monkeypatch):
+    monkeypatch.delenv("SHM_RENDERER_ALLOW_VERSIONS", raising=False)
+    monkeypatch.delenv("SHM_RENDERER_ALLOW_BUILDS", raising=False)
+    assert attestation._renderer_build_allowed("1041.0.15", "2026-07-09T19:06:39Z") is True
+    assert attestation._renderer_build_allowed("1042.0.0", "2026-07-09T19:06:39Z") is False
+
+
 def test_create_binds_exact_source_editor_payload_versions_and_screenshots(tmp_path):
     renderer = FakeRenderer()
     record = _create(tmp_path, renderer)
@@ -168,6 +175,7 @@ def test_safe_show_verifies_binding_and_redacts_all_mail_content(tmp_path):
         "empty_subject": False,
         "scheduled": False,
         "has_quote": True,
+        "editor_normalized_changed": False,
     }
     serialized = str(summary)
     assert "Hello" not in serialized
@@ -191,6 +199,14 @@ def test_safe_show_reports_valid_but_expired_as_unusable(tmp_path):
     assert summary["signature_valid"] is True
     assert summary["expired"] is True
     assert summary["usable"] is False
+
+
+def test_tampered_screenshot_is_rejected_even_when_record_signature_is_valid(tmp_path):
+    record = _create(tmp_path)
+    Path(record["screenshots"][0]["path"]).write_bytes(b"tampered")
+    with pytest.raises(attestation.AttestationError) as caught:
+        attestation.verify(record)
+    assert caught.value.code == "ATTESTATION_ARTIFACT_MISMATCH"
 
 
 def test_tampered_or_expired_attestation_is_rejected(tmp_path):
@@ -226,6 +242,30 @@ def test_dirty_renderer_version_mismatch_and_write_event_fail_closed(tmp_path):
                         renderer=renderer,
                     )
         assert caught.value.code == code
+
+
+def test_readable_attachment_bytes_are_stream_hashed():
+    attached = _draft(attachments=[{
+        "uuid": "attachment-fixture",
+        "source": {"type": "upload-firebase", "url": "https://example.test/file"},
+    }])
+
+    class Response:
+        def __init__(self):
+            self.chunks = iter([b"abc", b"def", b""])
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self, _size):
+            return next(self.chunks)
+
+    with patch("superhuman_mail.attestation.urllib.request.urlopen", return_value=Response()):
+        digests = attestation.attachment_digests(attached)
+    assert digests["attachment-fixture"] == attestation.sha256(b"abcdef")
 
 
 def test_unreadable_attachment_is_not_send_eligible(tmp_path):

--- a/tests/test_attestation.py
+++ b/tests/test_attestation.py
@@ -147,7 +147,10 @@ def test_bundled_renderer_declares_versioned_payload_contract():
     assert contract["mutates_mail_state"] is False
     assert contract["blocks_non_idempotent_before_dispatch"] is True
     assert contract["network_offline_during_render"] is True
-    assert set(contract["read_only_post_actions"]) == set(attestation._READ_ONLY_POST_ACTIONS)
+    assert {
+        origin: set(routes)
+        for origin, routes in contract["read_only_post_routes"].items()
+    } == attestation._READ_ONLY_POST_ROUTES
     assert contract["reminder"] == "persisted_draft_only_current_build"
     assert "html_body" in contract["outgoing_fields"]
     assert "reminder" not in contract["outgoing_fields"]
@@ -157,6 +160,8 @@ def test_bundled_renderer_policy_aborts_write_before_dispatch():
     script = Path(attestation.__file__).with_name("renderer_probe.js")
     requests = [
         {"method": "POST", "url": "https://mail.superhuman.com/~backend/v3/userdata.read"},
+        {"method": "POST", "url": "https://evil.example/~backend/v3/userdata.read"},
+        {"method": "POST", "url": "https://evil.example/~backend/v3/sessions.getTokens"},
         {"method": "POST", "url": "https://mail.superhuman.com/~backend/v3/userdata.writeMessage"},
         {"method": "DELETE", "url": "https://example.test/anything"},
     ]
@@ -168,7 +173,7 @@ def test_bundled_renderer_policy_aborts_write_before_dispatch():
         check=True,
     )
     decisions = json.loads(completed.stdout)
-    assert [item["disposition"] for item in decisions] == ["continue", "fail", "fail"]
+    assert [item["disposition"] for item in decisions] == ["continue", "fail", "fail", "fail", "fail"]
     source = script.read_text()
     assert 'this.send("Fetch.failRequest"' in source
     assert 'client.send("Page.bringToFront"' not in source
@@ -179,10 +184,12 @@ def test_probe_network_policy_fails_closed_on_unknown_non_idempotent_requests():
     events = [
         {"method": "GET", "url": "https://mail.superhuman.com/image.png"},
         {"method": "POST", "url": "https://mail.superhuman.com/~backend/v3/userdata.read"},
+        {"method": "POST", "url": "https://evil.example/~backend/v3/userdata.read"},
         {"method": "POST", "url": "https://mail.superhuman.com/~backend/v3/newMutation.unknown"},
         {"method": "DELETE", "url": "https://example.test/anything"},
     ]
     assert attestation._network_writes(events) == [
+        {"method": "POST", "url": "https://evil.example/~backend/v3/userdata.read"},
         {"method": "POST", "url": "https://mail.superhuman.com/~backend/v3/newmutation.unknown"},
         {"method": "DELETE", "url": "https://example.test/anything"},
     ]

--- a/tests/test_attestation.py
+++ b/tests/test_attestation.py
@@ -1,8 +1,9 @@
 """Exact render attestation, signing, and stale-check tests."""
 from __future__ import annotations
 
-import base64
 import copy
+import json
+import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import patch
@@ -115,8 +116,8 @@ class FakeRenderer:
 
 @pytest.fixture(autouse=True)
 def _key_and_version(monkeypatch, tmp_path):
-    monkeypatch.setenv("SHM_ATTESTATION_KEY", base64.urlsafe_b64encode(b"k" * 32).decode())
-    monkeypatch.setenv("SHM_RENDERER_ALLOW_VERSIONS", VERSION)
+    monkeypatch.setattr(attestation, "_attestation_key", lambda *, create: b"k" * 32)
+    monkeypatch.setattr(attestation, "DEFAULT_ALLOWED_RENDERER_BUILDS", {("1041.0.15", VERSION)})
     monkeypatch.setenv("SHM_STATE_DIR", str(tmp_path / "state"))
 
 
@@ -133,9 +134,44 @@ def _create(tmp_path, renderer=None):
             )
 
 
+def test_bundled_renderer_declares_versioned_payload_contract():
+    script = Path(attestation.__file__).with_name("renderer_probe.js")
+    completed = subprocess.run(
+        ["node", str(script), "--print-contract"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    contract = json.loads(completed.stdout)
+    assert contract["adapter_version"] == attestation.ADAPTER_VERSION
+    assert contract["mutates_mail_state"] is False
+    assert contract["reminder"] == "persisted_draft_only_current_build"
+    assert "html_body" in contract["outgoing_fields"]
+    assert "reminder" not in contract["outgoing_fields"]
+
+
+def test_probe_network_policy_fails_closed_on_unknown_non_idempotent_requests():
+    events = [
+        {"method": "GET", "url": "https://mail.superhuman.com/image.png"},
+        {"method": "POST", "url": "https://mail.superhuman.com/~backend/v3/userdata.read"},
+        {"method": "POST", "url": "https://mail.superhuman.com/~backend/v3/newMutation.unknown"},
+        {"method": "DELETE", "url": "https://example.test/anything"},
+    ]
+    assert attestation._network_writes(events) == [
+        {"method": "POST", "url": "https://mail.superhuman.com/~backend/v3/newmutation.unknown"},
+        {"method": "DELETE", "url": "https://example.test/anything"},
+    ]
+
+
+def test_renderer_rejects_non_loopback_cdp_endpoint(tmp_path):
+    renderer = attestation.CdpRenderer(cdp_url="https://attacker.example.test:9222")
+    with pytest.raises(attestation.AttestationError) as caught:
+        renderer.probe({}, output_dir=tmp_path)
+    assert caught.value.code == "RENDERER_ENDPOINT_UNSAFE"
+
+
 def test_production_allowlist_binds_app_and_web_versions(monkeypatch):
-    monkeypatch.delenv("SHM_RENDERER_ALLOW_VERSIONS", raising=False)
-    monkeypatch.delenv("SHM_RENDERER_ALLOW_BUILDS", raising=False)
+    monkeypatch.setattr(attestation, "DEFAULT_ALLOWED_RENDERER_BUILDS", {("1041.0.15", "2026-07-09T19:06:39Z")})
     assert attestation._renderer_build_allowed("1041.0.15", "2026-07-09T19:06:39Z") is True
     assert attestation._renderer_build_allowed("1042.0.0", "2026-07-09T19:06:39Z") is False
 
@@ -201,6 +237,12 @@ def test_safe_show_reports_valid_but_expired_as_unusable(tmp_path):
     assert summary["usable"] is False
 
 
+def test_malformed_attestation_returns_typed_invalid_error():
+    with pytest.raises(attestation.AttestationError) as caught:
+        attestation.verify({})
+    assert caught.value.code == "ATTESTATION_INVALID"
+
+
 def test_tampered_screenshot_is_rejected_even_when_record_signature_is_valid(tmp_path):
     record = _create(tmp_path)
     Path(record["screenshots"][0]["path"]).write_bytes(b"tampered")
@@ -247,7 +289,7 @@ def test_dirty_renderer_version_mismatch_and_write_event_fail_closed(tmp_path):
 def test_readable_attachment_bytes_are_stream_hashed():
     attached = _draft(attachments=[{
         "uuid": "attachment-fixture",
-        "source": {"type": "upload-firebase", "url": "https://example.test/file"},
+        "source": {"type": "upload-firebase", "url": "https://storage.googleapis.com/file"},
     }])
 
     class Response:
@@ -266,6 +308,18 @@ def test_readable_attachment_bytes_are_stream_hashed():
     with patch("superhuman_mail.attestation.urllib.request.urlopen", return_value=Response()):
         digests = attestation.attachment_digests(attached)
     assert digests["attachment-fixture"] == attestation.sha256(b"abcdef")
+
+
+def test_attachment_bytes_reject_non_allowlisted_source_without_request():
+    attached = _draft(attachments=[{
+        "uuid": "attachment-fixture",
+        "source": {"type": "upload-firebase", "url": "https://attacker.example.test/file"},
+    }])
+    with patch("superhuman_mail.attestation.urllib.request.urlopen") as urlopen:
+        with pytest.raises(attestation.AttestationError) as caught:
+            attestation.attachment_digests(attached)
+    assert caught.value.code == "UNATTESTABLE_ATTACHMENT"
+    urlopen.assert_not_called()
 
 
 def test_unreadable_attachment_is_not_send_eligible(tmp_path):

--- a/tests/test_attestation.py
+++ b/tests/test_attestation.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 import pytest
 
-from superhuman_mail import attestation, lifecycle
+from superhuman_mail import approval, attestation, lifecycle
 
 THREAD = "thread_fixture"
 DRAFT = "draft_fixture"
@@ -145,9 +145,33 @@ def test_bundled_renderer_declares_versioned_payload_contract():
     contract = json.loads(completed.stdout)
     assert contract["adapter_version"] == attestation.ADAPTER_VERSION
     assert contract["mutates_mail_state"] is False
+    assert contract["blocks_non_idempotent_before_dispatch"] is True
+    assert contract["network_offline_during_render"] is True
+    assert set(contract["read_only_post_actions"]) == set(attestation._READ_ONLY_POST_ACTIONS)
     assert contract["reminder"] == "persisted_draft_only_current_build"
     assert "html_body" in contract["outgoing_fields"]
     assert "reminder" not in contract["outgoing_fields"]
+
+
+def test_bundled_renderer_policy_aborts_write_before_dispatch():
+    script = Path(attestation.__file__).with_name("renderer_probe.js")
+    requests = [
+        {"method": "POST", "url": "https://mail.superhuman.com/~backend/v3/userdata.read"},
+        {"method": "POST", "url": "https://mail.superhuman.com/~backend/v3/userdata.writeMessage"},
+        {"method": "DELETE", "url": "https://example.test/anything"},
+    ]
+    completed = subprocess.run(
+        ["node", str(script), "--test-network-policy"],
+        input=json.dumps(requests),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    decisions = json.loads(completed.stdout)
+    assert [item["disposition"] for item in decisions] == ["continue", "fail", "fail"]
+    source = script.read_text()
+    assert 'this.send("Fetch.failRequest"' in source
+    assert source.index('client.send("Fetch.enable"') < source.index('client.send("Page.bringToFront"')
 
 
 def test_probe_network_policy_fails_closed_on_unknown_non_idempotent_requests():
@@ -203,6 +227,7 @@ def test_safe_show_verifies_binding_and_redacts_all_mail_content(tmp_path):
     assert summary["signature_valid"] is True
     assert summary["usable"] is True
     assert summary["binding_match"] is True
+    assert summary["approval_binding"] == approval.binding_for_attestation(record)
     assert summary["summary"] == {
         "to_count": 1,
         "cc_count": 0,

--- a/tests/test_cli_lifecycle_send.py
+++ b/tests/test_cli_lifecycle_send.py
@@ -30,6 +30,21 @@ def test_send_status_subcommand_spelling_maps_to_read_only_status(capsys):
     assert output["data"]["sent"] is False
 
 
+def test_active_or_terminal_failure_status_exits_one(capsys):
+    for state in ("active_draft", "send_failed", "send_aborted", "discarded", "inconsistent"):
+        with patch("superhuman_mail.cli._send.status", return_value=ok("send.status", _send_data(state))):
+            code = main(["send", "status", THREAD, DRAFT, "--account", ACCOUNT])
+        assert code == 1
+        capsys.readouterr()
+
+
+def test_scheduled_status_exits_zero_without_sent_claim(capsys):
+    with patch("superhuman_mail.cli._send.status", return_value=ok("send.status", _send_data("scheduled"))):
+        code = main(["send", "status", THREAD, DRAFT, "--account", ACCOUNT])
+    assert code == 0
+    assert json.loads(capsys.readouterr().out)["data"]["sent"] is False
+
+
 def test_provider_confirmed_status_exits_zero(capsys):
     with patch("superhuman_mail.cli._send.status", return_value=ok("send.status", _send_data("sent_provider_confirmed", sent=True))):
         code = main(["send", "status", THREAD, DRAFT, "--account", ACCOUNT])

--- a/tests/test_cli_lifecycle_send.py
+++ b/tests/test_cli_lifecycle_send.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from superhuman_mail.cli import main
 from superhuman_mail._envelope import ok
@@ -31,11 +31,18 @@ def test_send_status_subcommand_spelling_maps_to_read_only_status(capsys):
 
 
 def test_active_or_terminal_failure_status_exits_one(capsys):
-    for state in ("active_draft", "send_failed", "send_aborted", "discarded", "inconsistent"):
+    for state in ("active_draft", "send_failed", "send_aborted", "discarded"):
         with patch("superhuman_mail.cli._send.status", return_value=ok("send.status", _send_data(state))):
             code = main(["send", "status", THREAD, DRAFT, "--account", ACCOUNT])
         assert code == 1
         capsys.readouterr()
+
+
+def test_inconsistent_possible_send_status_exits_four(capsys):
+    with patch("superhuman_mail.cli._send.status", return_value=ok("send.status", _send_data("inconsistent"))):
+        code = main(["send", "status", THREAD, DRAFT, "--account", ACCOUNT])
+    assert code == 4
+    capsys.readouterr()
 
 
 def test_scheduled_status_exits_zero_without_sent_claim(capsys):
@@ -62,6 +69,8 @@ def test_confirm_passes_attestation_approval_and_wait_and_pending_exits_four(cap
             "--approval-ref", "approval_fixture",
             "--delay", "20",
             "--wait", "30",
+            "--cdp-url", "http://127.0.0.1:9333",
+            "--window-id", "123",
         ])
     assert code == 4
     execute.assert_called_once_with(
@@ -72,7 +81,11 @@ def test_confirm_passes_attestation_approval_and_wait_and_pending_exits_four(cap
         attestation="attestation_fixture",
         approval_ref="approval_fixture",
         wait=30.0,
+        renderer=ANY,
     )
+    renderer = execute.call_args.kwargs["renderer"]
+    assert renderer.cdp_url == "http://127.0.0.1:9333"
+    assert renderer.window_id == 123
     assert json.loads(capsys.readouterr().out)["data"]["sent"] is False
 
 

--- a/tests/test_cli_lifecycle_send.py
+++ b/tests/test_cli_lifecycle_send.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 from unittest.mock import ANY, patch
 
+from superhuman_mail import send
 from superhuman_mail.cli import main
 from superhuman_mail._envelope import ok
 
@@ -66,7 +67,7 @@ def test_confirm_passes_attestation_approval_and_wait_and_pending_exits_four(cap
             "send", "--confirm", THREAD, DRAFT,
             "--account", ACCOUNT,
             "--attestation", "attestation_fixture",
-            "--approval-ref", "approval_fixture",
+            "--approval-receipt", "receipt-fixture.json",
             "--delay", "20",
             "--wait", "30",
             "--cdp-url", "http://127.0.0.1:9333",
@@ -79,7 +80,8 @@ def test_confirm_passes_attestation_approval_and_wait_and_pending_exits_four(cap
         delay=20,
         account=ACCOUNT,
         attestation="attestation_fixture",
-        approval_ref="approval_fixture",
+        approval_receipt="receipt-fixture.json",
+        approval_ref=None,
         wait=30.0,
         renderer=ANY,
     )
@@ -89,12 +91,46 @@ def test_confirm_passes_attestation_approval_and_wait_and_pending_exits_four(cap
     assert json.loads(capsys.readouterr().out)["data"]["sent"] is False
 
 
+def test_approval_verify_delegates_external_authority_and_replay_check(capsys):
+    summary = {
+        "authority": "external_ed25519_receipt_v1",
+        "verified": True,
+        "usable": True,
+        "consumed": False,
+    }
+    with patch("superhuman_mail.cli._approval.show_safe", return_value=summary) as verify:
+        code = main([
+            "approval", "verify", "receipt.json",
+            "--attestation", "attestation-fixture",
+        ])
+    assert code == 0
+    verify.assert_called_once_with(
+        "receipt.json",
+        attestation_reference="attestation-fixture",
+    )
+    assert json.loads(capsys.readouterr().out)["data"]["verified"] is True
+
+
 def test_draft_read_passes_lifecycle_filters(capsys):
     with patch("superhuman_mail.cli._draft.read", return_value=ok("draft.read", {"drafts": []})) as read:
         code = main(["draft", "read", THREAD, "--draft-id", DRAFT, "--account", ACCOUNT, "--active-only"])
     assert code == 0
     read.assert_called_once_with(THREAD, draft_id=DRAFT, account=ACCOUNT, active_only=True)
     capsys.readouterr()
+
+
+def test_attest_render_terminal_preflight_returns_json_error_not_traceback(capsys, tmp_path):
+    safety_error = send.SendSafetyError("DRAFT_ALREADY_SENT", "already sent")
+    with patch("superhuman_mail.send._preflight", side_effect=safety_error):
+        code = main([
+            "draft", "attest-render", THREAD, DRAFT,
+            "--account", ACCOUNT,
+            "--output", str(tmp_path),
+        ])
+    result = json.loads(capsys.readouterr().out)
+    assert code == 1
+    assert result["status"] == "failed"
+    assert result["errors"][0]["code"] == "DRAFT_ALREADY_SENT"
 
 
 def test_attestation_show_delegates_signature_and_binding_verification(capsys):

--- a/tests/test_cli_lifecycle_send.py
+++ b/tests/test_cli_lifecycle_send.py
@@ -1,0 +1,130 @@
+"""CLI contracts for lifecycle, strict attestation, and pending exit status."""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from superhuman_mail.cli import main
+from superhuman_mail._envelope import ok
+
+THREAD = "thread_fixture"
+DRAFT = "draft_fixture"
+ACCOUNT = "owner@example.test"
+
+
+def _send_data(state, *, sent=False):
+    return {
+        "state": state,
+        "sent": sent,
+        "provider_confirmed": sent,
+        "attempt_id": "attempt_fixture",
+    }
+
+
+def test_send_status_subcommand_spelling_maps_to_read_only_status(capsys):
+    with patch("superhuman_mail.cli._send.status", return_value=ok("send.status", _send_data("send_pending_undo"))) as status:
+        code = main(["send", "status", THREAD, DRAFT, "--account", ACCOUNT, "--wait", "5"])
+    assert code == 4
+    status.assert_called_once_with(THREAD, DRAFT, account=ACCOUNT, wait=5.0)
+    output = json.loads(capsys.readouterr().out)
+    assert output["data"]["sent"] is False
+
+
+def test_provider_confirmed_status_exits_zero(capsys):
+    with patch("superhuman_mail.cli._send.status", return_value=ok("send.status", _send_data("sent_provider_confirmed", sent=True))):
+        code = main(["send", "status", THREAD, DRAFT, "--account", ACCOUNT])
+    assert code == 0
+    assert json.loads(capsys.readouterr().out)["data"]["provider_confirmed"] is True
+
+
+def test_confirm_passes_attestation_approval_and_wait_and_pending_exits_four(capsys):
+    result = ok("send", _send_data("sent_backend_confirmed", sent=False))
+    with patch("superhuman_mail.cli._send.execute", return_value=result) as execute:
+        code = main([
+            "send", "--confirm", THREAD, DRAFT,
+            "--account", ACCOUNT,
+            "--attestation", "attestation_fixture",
+            "--approval-ref", "approval_fixture",
+            "--delay", "20",
+            "--wait", "30",
+        ])
+    assert code == 4
+    execute.assert_called_once_with(
+        THREAD,
+        DRAFT,
+        delay=20,
+        account=ACCOUNT,
+        attestation="attestation_fixture",
+        approval_ref="approval_fixture",
+        wait=30.0,
+    )
+    assert json.loads(capsys.readouterr().out)["data"]["sent"] is False
+
+
+def test_draft_read_passes_lifecycle_filters(capsys):
+    with patch("superhuman_mail.cli._draft.read", return_value=ok("draft.read", {"drafts": []})) as read:
+        code = main(["draft", "read", THREAD, "--draft-id", DRAFT, "--account", ACCOUNT, "--active-only"])
+    assert code == 0
+    read.assert_called_once_with(THREAD, draft_id=DRAFT, account=ACCOUNT, active_only=True)
+    capsys.readouterr()
+
+
+def test_attestation_show_delegates_signature_and_binding_verification(capsys):
+    summary = {
+        "attestation_id": "attestation_fixture",
+        "signature_valid": True,
+        "expired": False,
+        "usable": True,
+        "summary": {"to_count": 1},
+    }
+    with patch("superhuman_mail.cli._attestation.show_safe", return_value=summary) as show:
+        code = main([
+            "attestation", "show", "attestation_fixture",
+            "--account", ACCOUNT,
+            "--thread-id", THREAD,
+            "--draft-id", DRAFT,
+        ])
+    assert code == 0
+    show.assert_called_once_with(
+        "attestation_fixture",
+        account=ACCOUNT,
+        thread_id=THREAD,
+        draft_id=DRAFT,
+    )
+    assert json.loads(capsys.readouterr().out)["data"]["usable"] is True
+
+
+def test_attest_render_emits_safe_summary_not_body_or_payload(capsys, tmp_path):
+    record = {
+        "attestation_id": "attestation_fixture",
+        "artifact_path": str(tmp_path / "record.json"),
+        "created_at": "2026-07-10T12:00:00Z",
+        "expires_at": "2026-07-10T12:15:00Z",
+        "send_eligible": True,
+        "confidence": "exact_superhuman_renderer",
+        "account": {"email": ACCOUNT, "provider_user_id": "user_fixture"},
+        "thread_id": THREAD,
+        "draft_id": DRAFT,
+        "superhuman_id": "sid.fixture",
+        "fingerprint": {"exact": "sha256:fixture"},
+        "renderer": {"web_version": "fixture"},
+        "screenshots": [],
+        "source": {"body": "PRIVATE BODY"},
+        "outgoing_payload": {"html_body": "PRIVATE BODY"},
+    }
+    with patch("superhuman_mail.cli._attestation.create", return_value=record) as create:
+        code = main([
+            "draft", "attest-render", THREAD, DRAFT,
+            "--account", ACCOUNT,
+            "--output", str(tmp_path),
+            "--cdp-url", "http://127.0.0.1:9333",
+        ])
+    assert code == 0
+    create.assert_called_once()
+    output_text = capsys.readouterr().out
+    assert "PRIVATE BODY" not in output_text
+    assert "user_fixture" not in output_text
+    assert "sid.fixture" not in output_text
+    output = json.loads(output_text)
+    assert output["data"]["attestation_id"] == "attestation_fixture"
+    assert output["data"]["send_eligible"] is True

--- a/tests/test_draft_lifecycle_read.py
+++ b/tests/test_draft_lifecycle_read.py
@@ -1,0 +1,61 @@
+"""Draft reads keep source objects but cannot hide terminal lifecycle."""
+from unittest.mock import patch
+
+from superhuman_mail import draft, lifecycle
+
+
+def _state(draft_id, state):
+    return {
+        "draft_id": draft_id,
+        "state": state,
+        "terminal": state in lifecycle.TERMINAL_STATES,
+        "send_blocked": state in lifecycle.BLOCKING_STATES,
+        "outbound_evidence": state == lifecycle.PROVIDER_CONFIRMED,
+    }
+
+
+def _observed():
+    return {
+        "account": {"email": "owner@example.test", "provider_user_id": "user-fixture"},
+        "thread_id": "thread-fixture",
+        "userdata": {
+            "messages": {
+                "draft_active": {"draft": {"id": "draft_active", "body": "active"}},
+                "draft_sent": {"draft": {"id": "draft_sent", "body": "residue"}},
+                "draft_pending": {"draft": {"id": "draft_pending", "body": "pending"}},
+            }
+        },
+        "lifecycle_by_draft_id": {
+            "draft_active": _state("draft_active", lifecycle.ACTIVE),
+            "draft_sent": _state("draft_sent", lifecycle.PROVIDER_CONFIRMED),
+            "draft_pending": _state("draft_pending", lifecycle.PENDING_UNDO),
+        },
+    }, []
+
+
+def test_read_exposes_active_terminal_and_pending_counts():
+    with patch("superhuman_mail.draft.lifecycle.observe_thread", return_value=_observed()):
+        result = draft.read("thread-fixture")
+    assert result["status"] == "succeeded"
+    assert result["data"]["draft_count"] == 3
+    assert result["data"]["active_draft_count"] == 1
+    assert result["data"]["terminal_draft_count"] == 1
+    assert result["data"]["nonterminal_blocked_draft_count"] == 1
+    assert result["data"]["lifecycle_by_draft_id"]["draft_sent"]["outbound_evidence"] is True
+    assert "terminal source draft" in result["warnings"][0]
+
+
+def test_active_only_hides_terminal_and_pending_source_residue():
+    with patch("superhuman_mail.draft.lifecycle.observe_thread", return_value=_observed()):
+        result = draft.read("thread-fixture", active_only=True)
+    assert [item["id"] for item in result["data"]["drafts"]] == ["draft_active"]
+    assert result["data"]["active_draft_count"] == 1
+    assert result["data"]["terminal_draft_count"] == 1
+
+
+def test_status_returns_lifecycle_without_source_draft_body():
+    with patch("superhuman_mail.draft.lifecycle.observe_thread", return_value=_observed()):
+        result = draft.status("thread-fixture", "draft_sent")
+    assert result["status"] == "succeeded"
+    assert result["data"]["lifecycle_by_draft_id"]["draft_sent"]["state"] == lifecycle.PROVIDER_CONFIRMED
+    assert "drafts" not in result["data"]

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -159,6 +159,8 @@ def test_not_sent_to_server_never_counts_as_an_accepted_schedule():
     )
     assert result["state"] == lifecycle.REQUESTED
     assert result["outbound_evidence"] is False
+    assert result["send_job"]["not_sent_to_server_present"] is True
+    assert result["send_job"]["not_sent_to_server"] is True
 
 
 @pytest.mark.parametrize(
@@ -172,6 +174,7 @@ def test_terminal_failure_states(job, expected):
     result = _classify(job=job)
     assert result["state"] == expected
     assert result["terminal"] is True
+    assert result["send_job"]["not_sent_to_server_present"] is False
     assert result["outbound_evidence"] is False
 
 

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -14,7 +14,7 @@ SID = "sid.fixture"
 MESSAGE = "message_fixture"
 
 
-def _userdata(*, draft=None, job=None, discarded=None, extra_messages=None):
+def _userdata(*, draft=None, job=None, discarded=None, sending=False, extra_messages=None):
     wrapper = {"draft": draft or {
         "id": DRAFT,
         "threadId": THREAD,
@@ -28,6 +28,8 @@ def _userdata(*, draft=None, job=None, discarded=None, extra_messages=None):
         wrapper["sendJob"] = job
     if discarded is not None:
         wrapper["discardedAt"] = discarded
+    if sending:
+        wrapper["sending"] = True
     messages = {DRAFT: wrapper}
     messages.update(extra_messages or {})
     return {"historyId": 42, "messages": messages}
@@ -46,12 +48,12 @@ def _provider(**overrides):
     return value
 
 
-def _classify(*, draft=None, job=None, discarded=None, providers=(), attempt_sid=None):
+def _classify(*, draft=None, job=None, discarded=None, sending=False, providers=(), attempt_sid=None):
     return lifecycle.classify(
         account=ACCOUNT,
         thread_id=THREAD,
         draft_id=DRAFT,
-        userdata=_userdata(draft=draft, job=job, discarded=discarded),
+        userdata=_userdata(draft=draft, job=job, discarded=discarded, sending=sending),
         provider_messages=providers,
         observed_at="2026-07-10T12:01:00Z",
         attempt_superhuman_id=attempt_sid,
@@ -63,6 +65,13 @@ def test_plain_active_draft_is_not_outbound_evidence():
     assert result["state"] == lifecycle.ACTIVE
     assert result["terminal"] is False
     assert result["outbound_evidence"] is False
+
+
+def test_wrapper_sending_flag_blocks_before_send_job_materializes():
+    result = _classify(sending=True)
+    assert result["state"] == lifecycle.REQUESTED
+    assert result["send_blocked"] is True
+    assert result["send_job"]["sending"] is True
 
 
 def test_newer_draft_does_not_match_unrelated_sent_message_in_same_thread():
@@ -237,6 +246,19 @@ def test_provider_confirmation_wins_material_outcome_but_surfaces_stale_failure(
     assert result["state"] == lifecycle.PROVIDER_CONFIRMED
     assert result["consistency"] == "conflicting"
     assert result["outbound_evidence"] is True
+
+
+def test_duplicate_provider_linkage_conflict_is_order_independent():
+    clean = _provider(id="message_clean")
+    conflicting = _provider(id="message_conflict", superhumanId="sid.other")
+    for providers in ([clean, conflicting], [conflicting, clean]):
+        result = _classify(
+            job={"superhumanId": SID},
+            providers=providers,
+            attempt_sid=SID,
+        )
+        assert result["state"] == lifecycle.PROVIDER_CONFIRMED
+        assert result["consistency"] == "conflicting"
 
 
 def test_draft_id_and_draft_label_never_set_outbound_evidence():

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,233 @@
+"""Adversarial lifecycle regression tests using fully synthetic mail data."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from superhuman_mail import lifecycle
+
+ACCOUNT = {"email": "owner@example.test", "provider_user_id": "user-fixture"}
+THREAD = "thread_fixture"
+DRAFT = "draft_fixture"
+SID = "sid.fixture"
+MESSAGE = "message_fixture"
+
+
+def _userdata(*, draft=None, job=None, discarded=None, extra_messages=None):
+    wrapper = {"draft": draft or {
+        "id": DRAFT,
+        "threadId": THREAD,
+        "from": {"email": ACCOUNT["email"]},
+        "to": [{"email": "recipient@example.test"}],
+        "subject": "Fixture",
+        "body": "<div>Hello</div>",
+        "labelIds": ["DRAFT"],
+    }}
+    if job is not None:
+        wrapper["sendJob"] = job
+    if discarded is not None:
+        wrapper["discardedAt"] = discarded
+    messages = {DRAFT: wrapper}
+    messages.update(extra_messages or {})
+    return {"historyId": 42, "messages": messages}
+
+
+def _provider(**overrides):
+    value = {
+        "id": MESSAGE,
+        "labelIds": ["SENT"],
+        "from": {"email": ACCOUNT["email"]},
+        "date": "2026-07-10T12:00:00Z",
+        "superhumanOwnDraftId": DRAFT,
+        "superhumanId": SID,
+    }
+    value.update(overrides)
+    return value
+
+
+def _classify(*, draft=None, job=None, discarded=None, providers=(), attempt_sid=None):
+    return lifecycle.classify(
+        account=ACCOUNT,
+        thread_id=THREAD,
+        draft_id=DRAFT,
+        userdata=_userdata(draft=draft, job=job, discarded=discarded),
+        provider_messages=providers,
+        observed_at="2026-07-10T12:01:00Z",
+        attempt_superhuman_id=attempt_sid,
+    )
+
+
+def test_plain_active_draft_is_not_outbound_evidence():
+    result = _classify()
+    assert result["state"] == lifecycle.ACTIVE
+    assert result["terminal"] is False
+    assert result["outbound_evidence"] is False
+
+
+def test_newer_draft_does_not_match_unrelated_sent_message_in_same_thread():
+    unrelated = _provider(id="message_older", superhumanOwnDraftId="draft_older", superhumanId="sid.older")
+    result = _classify(providers=[unrelated])
+    assert result["state"] == lifecycle.ACTIVE
+    assert result["outbound_evidence"] is False
+
+
+def test_raw_draft_residue_plus_completed_job_and_provider_is_confirmed():
+    result = _classify(
+        job={"messageId": MESSAGE, "superhumanId": SID, "sentAt": "2026-07-10T12:00:00Z"},
+        providers=[_provider()],
+    )
+    assert result["state"] == lifecycle.PROVIDER_CONFIRMED
+    assert result["outbound_evidence"] is True
+    assert result["provider_message"]["id"] == MESSAGE
+
+
+def test_provider_proof_a_allows_absent_optional_linkage_but_rejects_mismatch():
+    bare = _provider()
+    bare.pop("superhumanOwnDraftId")
+    bare.pop("superhumanId")
+    job = {"messageId": MESSAGE, "superhumanId": SID, "sentAt": "2026-07-10T12:00:00Z"}
+    assert _classify(job=job, providers=[bare])["state"] == lifecycle.PROVIDER_CONFIRMED
+
+    mismatch = _provider(superhumanOwnDraftId="draft_other")
+    result = _classify(job=job, providers=[mismatch])
+    assert result["state"] == lifecycle.INCONSISTENT
+    assert result["outbound_evidence"] is False
+
+
+def test_provider_proof_b_requires_both_draft_and_superhuman_ids():
+    provider = _provider()
+    confirmed = _classify(job={"superhumanId": SID}, providers=[provider])
+    assert confirmed["state"] == lifecycle.PROVIDER_CONFIRMED
+
+    missing_sid = dict(provider)
+    missing_sid.pop("superhumanId")
+    result = _classify(job={"superhumanId": SID}, providers=[missing_sid])
+    assert result["state"] == lifecycle.INCONSISTENT
+    assert result["outbound_evidence"] is False
+
+
+def test_provider_message_must_be_sent_and_from_bound_account():
+    job = {"messageId": MESSAGE, "superhumanId": SID, "sentAt": "2026-07-10T12:00:00Z"}
+    not_sent = _classify(job=job, providers=[_provider(labelIds=["INBOX"])])
+    wrong_sender = _classify(job=job, providers=[_provider(**{"from": {"email": "other@example.test"}})])
+    assert not_sent["state"] == lifecycle.BACKEND_CONFIRMED
+    assert wrong_sender["state"] == lifecycle.BACKEND_CONFIRMED
+    assert not_sent["outbound_evidence"] is False
+
+
+def test_scheduled_for_without_job_remains_active():
+    draft = _userdata()["messages"][DRAFT]["draft"] | {"scheduledFor": "2030-01-01T09:00:00Z"}
+    result = _classify(draft=draft)
+    assert result["state"] == lifecycle.ACTIVE
+
+
+def test_future_send_job_with_scheduled_intent_is_scheduled():
+    future = (datetime.now(timezone.utc) + timedelta(days=1)).isoformat()
+    draft = _userdata()["messages"][DRAFT]["draft"] | {"scheduledFor": future}
+    result = _classify(draft=draft, job={"sendAt": future, "superhumanId": SID})
+    assert result["state"] == lifecycle.SCHEDULED
+    assert result["outbound_evidence"] is False
+
+
+def test_optimistic_and_undo_jobs_are_nonterminal():
+    optimistic = _classify(job={"notSentToServer": True, "superhumanId": SID})
+    undo = _classify(job={
+        "sendAt": (datetime.now(timezone.utc) + timedelta(seconds=20)).isoformat(),
+        "superhumanId": SID,
+    })
+    assert optimistic["state"] == lifecycle.REQUESTED
+    assert undo["state"] == lifecycle.PENDING_UNDO
+    assert optimistic["send_blocked"] and undo["send_blocked"]
+
+
+@pytest.mark.parametrize(
+    ("job", "expected"),
+    [
+        ({"failedAt": "2026-07-10T12:00:00Z"}, lifecycle.FAILED),
+        ({"abortedAt": "2026-07-10T12:00:00Z"}, lifecycle.ABORTED),
+    ],
+)
+def test_terminal_failure_states(job, expected):
+    result = _classify(job=job)
+    assert result["state"] == expected
+    assert result["terminal"] is True
+    assert result["outbound_evidence"] is False
+
+
+def test_discarded_source_is_terminal_not_outbound():
+    result = _classify(discarded="2026-07-10T12:00:00Z")
+    assert result["state"] == lifecycle.DISCARDED
+    assert result["terminal"] is True
+    assert result["outbound_evidence"] is False
+
+
+def test_backend_terminal_without_provider_is_not_business_outbound_proof():
+    result = _classify(job={"messageId": MESSAGE, "superhumanId": SID, "sentAt": "2026-07-10T12:00:00Z"})
+    assert result["state"] == lifecycle.BACKEND_CONFIRMED
+    assert result["outbound_evidence"] is False
+
+
+def test_provider_confirmation_survives_source_draft_cleanup():
+    userdata = {
+        "historyId": 43,
+        "messages": {DRAFT: {"sendJob": {
+            "messageId": MESSAGE,
+            "superhumanId": SID,
+            "sentAt": "2026-07-10T12:00:00Z",
+        }}},
+    }
+    result = lifecycle.classify(
+        account=ACCOUNT,
+        thread_id=THREAD,
+        draft_id=DRAFT,
+        userdata=userdata,
+        provider_messages=[_provider()],
+        observed_at="2026-07-10T12:01:00Z",
+    )
+    assert result["state"] == lifecycle.PROVIDER_CONFIRMED
+    assert result["outbound_evidence"] is True
+
+
+def test_provider_can_confirm_when_userdata_message_id_lags_using_attempt_identity():
+    result = _classify(job={}, providers=[_provider()], attempt_sid=SID)
+    assert result["state"] == lifecycle.PROVIDER_CONFIRMED
+    assert result["outbound_evidence"] is True
+
+
+def test_backend_success_plus_failure_without_provider_is_inconsistent():
+    result = _classify(job={
+        "messageId": MESSAGE,
+        "superhumanId": SID,
+        "sentAt": "2026-07-10T12:00:00Z",
+        "failedAt": "2026-07-10T12:00:01Z",
+    })
+    assert result["state"] == lifecycle.INCONSISTENT
+    assert result["consistency"] == "conflicting"
+    assert result["outbound_evidence"] is False
+
+
+def test_provider_confirmation_wins_material_outcome_but_surfaces_stale_failure():
+    result = _classify(
+        job={
+            "messageId": MESSAGE,
+            "superhumanId": SID,
+            "sentAt": "2026-07-10T12:00:00Z",
+            "failedAt": "2026-07-10T12:00:01Z",
+        },
+        providers=[_provider()],
+    )
+    assert result["state"] == lifecycle.PROVIDER_CONFIRMED
+    assert result["consistency"] == "conflicting"
+    assert result["outbound_evidence"] is True
+
+
+def test_draft_id_and_draft_label_never_set_outbound_evidence():
+    draft = _userdata()["messages"][DRAFT]["draft"] | {
+        "date": "2026-07-10T12:00:00Z",
+        "clientCreatedAt": 1783684800000,
+        "labelIds": ["DRAFT", "SENT"],
+    }
+    result = _classify(draft=draft)
+    assert result["state"] == lifecycle.ACTIVE
+    assert result["outbound_evidence"] is False

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -141,6 +141,17 @@ def test_optimistic_and_undo_jobs_are_nonterminal():
     assert optimistic["send_blocked"] and undo["send_blocked"]
 
 
+def test_not_sent_to_server_never_counts_as_an_accepted_schedule():
+    future = (datetime.now(timezone.utc) + timedelta(days=1)).isoformat()
+    draft = _userdata()["messages"][DRAFT]["draft"] | {"scheduledFor": future}
+    result = _classify(
+        draft=draft,
+        job={"sendAt": future, "superhumanId": SID, "notSentToServer": True},
+    )
+    assert result["state"] == lifecycle.REQUESTED
+    assert result["outbound_evidence"] is False
+
+
 @pytest.mark.parametrize(
     ("job", "expected"),
     [
@@ -159,6 +170,12 @@ def test_discarded_source_is_terminal_not_outbound():
     result = _classify(discarded="2026-07-10T12:00:00Z")
     assert result["state"] == lifecycle.DISCARDED
     assert result["terminal"] is True
+    assert result["outbound_evidence"] is False
+
+
+def test_partial_backend_terminal_evidence_is_inconsistent():
+    result = _classify(job={"superhumanId": SID, "sentAt": "2026-07-10T12:00:00Z"})
+    assert result["state"] == lifecycle.INCONSISTENT
     assert result["outbound_evidence"] is False
 
 

--- a/tests/test_lifecycle_observe.py
+++ b/tests/test_lifecycle_observe.py
@@ -1,0 +1,92 @@
+"""Live-join lifecycle observation tests; all data sources are synthetic."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from superhuman_mail import lifecycle
+
+ACCOUNT = {"email": "owner@example.test", "provider_user_id": "user-fixture"}
+THREAD = "draft_thread_fixture"
+REPLACEMENT = "provider_thread_fixture"
+DRAFT = "draft_fixture"
+MESSAGE = "message_fixture"
+SID = "sid.fixture"
+
+
+def _userdata(*, replacement=None):
+    data = {
+        "historyId": 42,
+        "messages": {
+            DRAFT: {
+                "draft": {
+                    "id": DRAFT,
+                    "threadId": THREAD,
+                    "from": {"email": ACCOUNT["email"]},
+                    "to": [{"email": "recipient@example.test"}],
+                    "subject": "Fixture",
+                    "body": "<div>Hello</div>",
+                    "labelIds": ["DRAFT"],
+                },
+                "sendJob": {
+                    "messageId": MESSAGE,
+                    "superhumanId": SID,
+                    "sentAt": "2026-07-10T12:00:00Z",
+                },
+            }
+        },
+    }
+    if replacement:
+        data["threadReplacement"] = replacement
+    return data
+
+
+def _provider():
+    return {
+        "id": MESSAGE,
+        "labelIds": ["SENT"],
+        "from": {"email": ACCOUNT["email"]},
+        "date": "2026-07-10T12:00:01Z",
+        "superhumanOwnDraftId": DRAFT,
+        "superhumanId": SID,
+    }
+
+
+def test_observe_thread_follows_synthetic_thread_replacement_for_provider_proof():
+    userdata = _userdata(replacement=REPLACEMENT)
+    with patch("superhuman_mail.lifecycle.resolve_account", return_value=(ACCOUNT, [])):
+        with patch("superhuman_mail.lifecycle._thread.userdata_raw", return_value=userdata):
+            with patch(
+                "superhuman_mail.lifecycle._local.get_thread_json",
+                side_effect=[{"messages": []}, {"messages": [_provider()]}],
+            ) as local_read:
+                observed, warnings = lifecycle.observe_thread(
+                    THREAD,
+                    account=ACCOUNT["email"],
+                    require_explicit_account=True,
+                )
+    assert warnings == []
+    assert [call.args[0] for call in local_read.call_args_list] == [THREAD, REPLACEMENT]
+    assert observed["provider_thread_id"] == REPLACEMENT
+    assert observed["lifecycle_by_draft_id"][DRAFT]["state"] == lifecycle.PROVIDER_CONFIRMED
+    assert observed["lifecycle_by_draft_id"][DRAFT]["provider_message"]["thread_id"] == REPLACEMENT
+
+
+def test_observe_returns_exact_wrapper_and_provider_cache_warning():
+    userdata = _userdata()
+    with patch("superhuman_mail.lifecycle.resolve_account", return_value=(ACCOUNT, [])):
+        with patch("superhuman_mail.lifecycle._thread.userdata_raw", return_value=userdata):
+            with patch(
+                "superhuman_mail.lifecycle._local.get_thread_json",
+                side_effect=RuntimeError("cache offline"),
+            ):
+                state, wrapper, warnings = lifecycle.observe(
+                    THREAD,
+                    DRAFT,
+                    account=ACCOUNT["email"],
+                    require_explicit_account=True,
+                    attempt_superhuman_id=SID,
+                )
+    assert wrapper is userdata["messages"][DRAFT]
+    assert state["state"] == lifecycle.BACKEND_CONFIRMED
+    assert state["outbound_evidence"] is False
+    assert warnings == [f"Provider cache unavailable for {THREAD}: cache offline"]

--- a/tests/test_send_attempt_flow.py
+++ b/tests/test_send_attempt_flow.py
@@ -232,7 +232,7 @@ def test_recorded_provider_confirmation_is_not_downgraded_by_stale_cache(tmp_pat
             with patch("superhuman_mail.send._attestation.verify"):
                 with patch("superhuman_mail.send._approval.load_and_verify", return_value=({}, _approval())):
                     with patch("superhuman_mail.send.lifecycle.resolve_account", return_value=(ACCOUNT, [])):
-                        with patch("superhuman_mail.send.lifecycle.observe", return_value=_observe(_state(lifecycle.ACTIVE))):
+                        with patch("superhuman_mail.send.lifecycle.observe", side_effect=LookupError("draft removed")) as observe:
                             with patch("superhuman_mail.send._post_exact_payload") as post:
                                 result = send.execute(
                                     THREAD,
@@ -246,7 +246,9 @@ def test_recorded_provider_confirmation_is_not_downgraded_by_stale_cache(tmp_pat
     assert result["status"] == "succeeded"
     assert result["data"]["sent"] is True
     assert result["data"]["state"] == lifecycle.PROVIDER_CONFIRMED
-    assert result["data"]["lifecycle"]["consistency"] == "observation_lag"
+    assert result["data"]["lifecycle"]["consistency"] == "journal_tombstone"
+    assert "tombstone" in result["warnings"][0]
+    observe.assert_not_called()
     preflight.assert_not_called()
     post.assert_not_called()
 

--- a/tests/test_send_attempt_flow.py
+++ b/tests/test_send_attempt_flow.py
@@ -216,6 +216,30 @@ def test_unknown_outcome_remains_non_sent_and_cannot_claim_again(tmp_path):
     assert claimed is False
 
 
+def test_status_without_local_attempt_waits_for_native_job_provider_confirmation(tmp_path):
+    journal = AttemptJournal(tmp_path / "attempts.sqlite3")
+    states = [
+        _observe(_state(lifecycle.PENDING_UNDO)),
+        _observe(_state(lifecycle.BACKEND_CONFIRMED)),
+        _observe(_state(lifecycle.PROVIDER_CONFIRMED, provider_id="message_fixture")),
+    ]
+    with patch("superhuman_mail.send.lifecycle.resolve_account", return_value=(ACCOUNT, [])):
+        with patch("superhuman_mail.send.lifecycle.observe", side_effect=states) as observe:
+            with patch("superhuman_mail.send.time.monotonic", return_value=0):
+                with patch("superhuman_mail.send.time.sleep"):
+                    result = send.status(
+                        THREAD,
+                        DRAFT,
+                        account=ACCOUNT["email"],
+                        wait=120,
+                        journal=journal,
+                    )
+    assert observe.call_count == 3
+    assert result["status"] == "succeeded"
+    assert result["data"]["sent"] is True
+    assert result["data"]["provider_message_id"] == "message_fixture"
+
+
 def test_future_scheduled_job_is_success_without_sent_claim(tmp_path):
     journal = AttemptJournal(tmp_path / "attempts.sqlite3")
     result, _post = _run(journal, _state(lifecycle.SCHEDULED))

--- a/tests/test_send_attempt_flow.py
+++ b/tests/test_send_attempt_flow.py
@@ -27,6 +27,31 @@ def _record():
     }
 
 
+def _approval():
+    return {
+        "receipt_id": "sha256:receipt-fixture",
+        "receipt_digest": "sha256:receipt-digest",
+        "issuer": "issuer-fixture",
+        "key_id": "key-fixture",
+        "approver": "slack:user-fixture",
+        "issued_at": "2026-07-10T12:00:00Z",
+        "expires_at": "2099-07-10T12:05:00Z",
+    }
+
+
+def _attempt_approval_kwargs():
+    verified = _approval()
+    return {
+        "approval_receipt_id": verified["receipt_id"],
+        "approval_receipt_digest": verified["receipt_digest"],
+        "approval_issuer": verified["issuer"],
+        "approval_key_id": verified["key_id"],
+        "approval_approver": verified["approver"],
+        "approval_issued_at": verified["issued_at"],
+        "approval_expires_at": verified["expires_at"],
+    }
+
+
 def _state(name, *, provider_id=None):
     return {
         "account": ACCOUNT,
@@ -62,19 +87,20 @@ def _run(journal, state, *, post_side_effect=None, wait=0):
     with patch("superhuman_mail.send._preflight", return_value=_preflight()):
         with patch("superhuman_mail.send._attestation.load", return_value=_record()):
             with patch("superhuman_mail.send._attestation.verify"):
-                with patch("superhuman_mail.send._attestation.revalidate_for_send", return_value={"outgoing_payload": {"fixture": True}}):
-                    with patch("superhuman_mail.send.lifecycle.resolve_account", return_value=(ACCOUNT, [])):
-                        with patch("superhuman_mail.send.lifecycle.observe", return_value=_observe(state)):
-                            with patch("superhuman_mail.send._post_exact_payload", side_effect=post_side_effect) as post:
-                                result = send.execute(
-                                    THREAD,
-                                    DRAFT,
-                                    account=ACCOUNT["email"],
-                                    attestation="attestation_fixture",
-                                    approval_ref="approval_fixture",
-                                    wait=wait,
-                                    journal=journal,
-                                )
+                with patch("superhuman_mail.send._approval.load_and_verify", return_value=({}, _approval())):
+                    with patch("superhuman_mail.send._attestation.revalidate_for_send", return_value={"outgoing_payload": {"fixture": True}}):
+                        with patch("superhuman_mail.send.lifecycle.resolve_account", return_value=(ACCOUNT, [])):
+                            with patch("superhuman_mail.send.lifecycle.observe", return_value=_observe(state)):
+                                with patch("superhuman_mail.send._post_exact_payload", side_effect=post_side_effect) as post:
+                                    result = send.execute(
+                                        THREAD,
+                                        DRAFT,
+                                        account=ACCOUNT["email"],
+                                        attestation="attestation_fixture",
+                                        approval_receipt="receipt-fixture.json",
+                                        wait=wait,
+                                        journal=journal,
+                                    )
     return result, post
 
 
@@ -114,21 +140,22 @@ def test_stale_second_probe_never_creates_or_strands_attempt(tmp_path):
     with patch("superhuman_mail.send._preflight", return_value=_preflight()):
         with patch("superhuman_mail.send._attestation.load", return_value=_record()):
             with patch("superhuman_mail.send._attestation.verify"):
-                with patch(
-                    "superhuman_mail.send._attestation.revalidate_for_send",
-                    side_effect=AttestationError("STALE_ATTESTATION", "changed"),
-                ):
-                    with patch("superhuman_mail.send.lifecycle.resolve_account", return_value=(ACCOUNT, [])):
-                        with patch("superhuman_mail.send._post_exact_payload") as post:
-                            result = send.execute(
-                                THREAD,
-                                DRAFT,
-                                account=ACCOUNT["email"],
-                                attestation="attestation_fixture",
-                                approval_ref="approval_fixture",
-                                wait=0,
-                                journal=journal,
-                            )
+                with patch("superhuman_mail.send._approval.load_and_verify", return_value=({}, _approval())):
+                    with patch(
+                        "superhuman_mail.send._attestation.revalidate_for_send",
+                        side_effect=AttestationError("STALE_ATTESTATION", "changed"),
+                    ):
+                        with patch("superhuman_mail.send.lifecycle.resolve_account", return_value=(ACCOUNT, [])):
+                            with patch("superhuman_mail.send._post_exact_payload") as post:
+                                result = send.execute(
+                                    THREAD,
+                                    DRAFT,
+                                    account=ACCOUNT["email"],
+                                    attestation="attestation_fixture",
+                                    approval_receipt="receipt-fixture.json",
+                                    wait=0,
+                                    journal=journal,
+                                )
     assert result["status"] == "failed"
     assert result["errors"][0]["code"] == "STALE_ATTESTATION"
     assert journal.get(ACCOUNT["provider_user_id"], DRAFT) is None
@@ -144,9 +171,11 @@ def test_http_acceptance_during_undo_window_is_pending_not_sent(tmp_path):
     assert result["data"]["accepted"] is True
     assert result["data"]["sent"] is False
     assert result["data"]["provider_confirmed"] is False
-    assert result["data"]["approval_authority"] == "correlation_only"
-    assert result["data"]["approval_verified"] is False
+    assert result["data"]["approval_authority"] == "external_ed25519_receipt_v1"
+    assert result["data"]["approval_verified"] is True
+    assert result["data"]["approval_consumed"] is True
     assert result["data"]["unattended_send_eligible"] is False
+    assert result["data"]["trusted_executor_required"] is True
     assert result["data"]["idempotency_scope"] == "local_cooperating_processes"
 
 
@@ -171,19 +200,20 @@ def test_retry_reconciles_existing_attempt_without_second_probe_or_post(tmp_path
     with patch("superhuman_mail.send._preflight") as preflight:
         with patch("superhuman_mail.send._attestation.load", return_value=_record()):
             with patch("superhuman_mail.send._attestation.verify"):
-                with patch("superhuman_mail.send._attestation.revalidate_for_send") as probe:
-                    with patch("superhuman_mail.send.lifecycle.resolve_account", return_value=(ACCOUNT, [])):
-                        with patch("superhuman_mail.send.lifecycle.observe", return_value=_observe(state)):
-                            with patch("superhuman_mail.send._post_exact_payload") as second_post:
-                                retried = send.execute(
-                                    THREAD,
-                                    DRAFT,
-                                    account=ACCOUNT["email"],
-                                    attestation="attestation_fixture",
-                                    approval_ref="approval_fixture",
-                                    wait=0,
-                                    journal=journal,
-                                )
+                with patch("superhuman_mail.send._approval.load_and_verify", return_value=({}, _approval())):
+                    with patch("superhuman_mail.send._attestation.revalidate_for_send") as probe:
+                        with patch("superhuman_mail.send.lifecycle.resolve_account", return_value=(ACCOUNT, [])):
+                            with patch("superhuman_mail.send.lifecycle.observe", return_value=_observe(state)):
+                                with patch("superhuman_mail.send._post_exact_payload") as second_post:
+                                    retried = send.execute(
+                                        THREAD,
+                                        DRAFT,
+                                        account=ACCOUNT["email"],
+                                        attestation="attestation_fixture",
+                                        approval_receipt="receipt-fixture.json",
+                                        wait=0,
+                                        journal=journal,
+                                    )
     assert retried["data"]["sent"] is True
     second_post.assert_not_called()
     probe.assert_not_called()
@@ -200,18 +230,19 @@ def test_recorded_provider_confirmation_is_not_downgraded_by_stale_cache(tmp_pat
     with patch("superhuman_mail.send._preflight") as preflight:
         with patch("superhuman_mail.send._attestation.load", return_value=_record()):
             with patch("superhuman_mail.send._attestation.verify"):
-                with patch("superhuman_mail.send.lifecycle.resolve_account", return_value=(ACCOUNT, [])):
-                    with patch("superhuman_mail.send.lifecycle.observe", return_value=_observe(_state(lifecycle.ACTIVE))):
-                        with patch("superhuman_mail.send._post_exact_payload") as post:
-                            result = send.execute(
-                                THREAD,
-                                DRAFT,
-                                account=ACCOUNT["email"],
-                                attestation="attestation_fixture",
-                                approval_ref="approval_fixture",
-                                wait=0,
-                                journal=journal,
-                            )
+                with patch("superhuman_mail.send._approval.load_and_verify", return_value=({}, _approval())):
+                    with patch("superhuman_mail.send.lifecycle.resolve_account", return_value=(ACCOUNT, [])):
+                        with patch("superhuman_mail.send.lifecycle.observe", return_value=_observe(_state(lifecycle.ACTIVE))):
+                            with patch("superhuman_mail.send._post_exact_payload") as post:
+                                result = send.execute(
+                                    THREAD,
+                                    DRAFT,
+                                    account=ACCOUNT["email"],
+                                    attestation="attestation_fixture",
+                                    approval_receipt="receipt-fixture.json",
+                                    wait=0,
+                                    journal=journal,
+                                )
     assert result["status"] == "succeeded"
     assert result["data"]["sent"] is True
     assert result["data"]["state"] == lifecycle.PROVIDER_CONFIRMED
@@ -247,7 +278,12 @@ def test_unknown_outcome_remains_non_sent_and_cannot_claim_again(tmp_path):
     assert result["data"]["accepted"] is False
     stored = journal.get(ACCOUNT["provider_user_id"], DRAFT)
     assert stored["state"] == "unknown"
-    _row, claimed = journal.claim_post(stored["attempt_id"])
+    _row, claimed = journal.claim_post(
+        stored["attempt_id"],
+        approval_receipt_id=_approval()["receipt_id"],
+        approval_receipt_digest=_approval()["receipt_digest"],
+        approval_expires_at=_approval()["expires_at"],
+    )
     assert claimed is False
 
 
@@ -259,7 +295,7 @@ def test_status_does_not_brick_never_posted_prepared_attempt(tmp_path):
         thread_id=THREAD,
         draft_id=DRAFT,
         attestation_id="attestation_fixture",
-        approval_ref="approval_fixture",
+        **_attempt_approval_kwargs(),
         superhuman_id=SID,
         outgoing_fingerprint="sha256:approved",
     )
@@ -288,24 +324,25 @@ def test_concurrent_prepared_rotation_surfaces_attempt_conflict_not_key_error(tm
         thread_id=THREAD,
         draft_id=DRAFT,
         attestation_id="attestation_fixture",
-        approval_ref="approval_fixture",
+        **_attempt_approval_kwargs(),
         superhuman_id=SID,
         outgoing_fingerprint="sha256:approved",
     )
     with patch("superhuman_mail.send._attestation.load", return_value=_record()):
         with patch("superhuman_mail.send._attestation.verify"):
-            with patch("superhuman_mail.send._attestation.revalidate_for_send", return_value={"outgoing_payload": {"fixture": True}}):
-                with patch("superhuman_mail.send.lifecycle.resolve_account", return_value=(ACCOUNT, [])):
-                    with patch.object(journal, "claim_post", side_effect=KeyError("rotated")):
-                        with patch("superhuman_mail.send._post_exact_payload") as post:
-                            result = send.execute(
-                                THREAD,
-                                DRAFT,
-                                account=ACCOUNT["email"],
-                                attestation="attestation_fixture",
-                                approval_ref="approval_fixture",
-                                journal=journal,
-                            )
+            with patch("superhuman_mail.send._approval.load_and_verify", return_value=({}, _approval())):
+                with patch("superhuman_mail.send._attestation.revalidate_for_send", return_value={"outgoing_payload": {"fixture": True}}):
+                    with patch("superhuman_mail.send.lifecycle.resolve_account", return_value=(ACCOUNT, [])):
+                        with patch.object(journal, "claim_post", side_effect=KeyError("rotated")):
+                            with patch("superhuman_mail.send._post_exact_payload") as post:
+                                result = send.execute(
+                                    THREAD,
+                                    DRAFT,
+                                    account=ACCOUNT["email"],
+                                    attestation="attestation_fixture",
+                                    approval_receipt="receipt-fixture.json",
+                                    journal=journal,
+                                )
     assert result["status"] == "failed"
     assert result["errors"][0]["code"] == "ATTEMPT_CONFLICT"
     post.assert_not_called()
@@ -319,7 +356,7 @@ def test_status_rejects_thread_mismatch_for_existing_attempt(tmp_path):
         thread_id=THREAD,
         draft_id=DRAFT,
         attestation_id="attestation_fixture",
-        approval_ref="approval_fixture",
+        **_attempt_approval_kwargs(),
         superhuman_id=SID,
         outgoing_fingerprint="sha256:approved",
     )
@@ -329,6 +366,35 @@ def test_status_rejects_thread_mismatch_for_existing_attempt(tmp_path):
     assert result["status"] == "failed"
     assert result["errors"][0]["code"] == "ATTEMPT_THREAD_MISMATCH"
     observe.assert_not_called()
+
+
+def test_client_local_terminal_job_is_not_reported_as_server_accepted(tmp_path):
+    journal = AttemptJournal(tmp_path / "attempts.sqlite3")
+    failed = _state(lifecycle.FAILED)
+    failed["send_job"] = {
+        "present": True,
+        "not_sent_to_server_present": True,
+        "not_sent_to_server": True,
+    }
+    with patch("superhuman_mail.send.lifecycle.resolve_account", return_value=(ACCOUNT, [])):
+        with patch("superhuman_mail.send.lifecycle.observe", return_value=_observe(failed)):
+            result = send.status(THREAD, DRAFT, account=ACCOUNT["email"], journal=journal)
+    assert result["data"]["state"] == lifecycle.FAILED
+    assert result["data"]["accepted"] is False
+
+
+def test_explicit_server_side_terminal_job_is_reported_as_accepted_request(tmp_path):
+    journal = AttemptJournal(tmp_path / "attempts.sqlite3")
+    failed = _state(lifecycle.FAILED)
+    failed["send_job"] = {
+        "present": True,
+        "not_sent_to_server_present": True,
+        "not_sent_to_server": False,
+    }
+    with patch("superhuman_mail.send.lifecycle.resolve_account", return_value=(ACCOUNT, [])):
+        with patch("superhuman_mail.send.lifecycle.observe", return_value=_observe(failed)):
+            result = send.status(THREAD, DRAFT, account=ACCOUNT["email"], journal=journal)
+    assert result["data"]["accepted"] is True
 
 
 def test_status_without_local_attempt_waits_for_native_job_provider_confirmation(tmp_path):
@@ -380,7 +446,7 @@ def test_concurrent_local_callers_share_one_post_claim(tmp_path):
             DRAFT,
             account=ACCOUNT["email"],
             attestation="attestation_fixture",
-            approval_ref="approval_fixture",
+            approval_receipt="receipt-fixture.json",
             wait=0,
             journal=journal,
         )
@@ -390,12 +456,13 @@ def test_concurrent_local_callers_share_one_post_claim(tmp_path):
     with patch("superhuman_mail.send._preflight", return_value=_preflight()):
         with patch("superhuman_mail.send._attestation.load", return_value=_record()):
             with patch("superhuman_mail.send._attestation.verify"):
-                with patch("superhuman_mail.send._attestation.revalidate_for_send", return_value={"outgoing_payload": {"fixture": True}}):
-                    with patch("superhuman_mail.send.lifecycle.resolve_account", return_value=(ACCOUNT, [])):
-                        with patch("superhuman_mail.send.lifecycle.observe", return_value=_observe(_state(lifecycle.PROVIDER_CONFIRMED, provider_id="message_fixture"))):
-                            with patch("superhuman_mail.send._post_exact_payload", side_effect=post):
-                                with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
-                                    results = list(pool.map(lambda _index: call(), range(2)))
+                with patch("superhuman_mail.send._approval.load_and_verify", return_value=({}, _approval())):
+                    with patch("superhuman_mail.send._attestation.revalidate_for_send", return_value={"outgoing_payload": {"fixture": True}}):
+                        with patch("superhuman_mail.send.lifecycle.resolve_account", return_value=(ACCOUNT, [])):
+                            with patch("superhuman_mail.send.lifecycle.observe", return_value=_observe(_state(lifecycle.PROVIDER_CONFIRMED, provider_id="message_fixture"))):
+                                with patch("superhuman_mail.send._post_exact_payload", side_effect=post):
+                                    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+                                        results = list(pool.map(lambda _index: call(), range(2)))
     assert counter == 1
     assert all(result["status"] == "succeeded" for result in results)
     assert journal_path.exists()

--- a/tests/test_send_attempt_flow.py
+++ b/tests/test_send_attempt_flow.py
@@ -1,0 +1,263 @@
+"""Strict send attempt/reconciliation tests with no live transport."""
+from __future__ import annotations
+
+import concurrent.futures
+import threading
+import urllib.error
+from unittest.mock import patch
+
+from superhuman_mail import lifecycle, send
+from superhuman_mail.attempts import AttemptJournal
+
+THREAD = "thread_fixture"
+DRAFT = "draft_fixture"
+SID = "sid.fixture"
+ACCOUNT = {"email": "owner@example.test", "provider_user_id": "user-fixture"}
+
+
+def _record():
+    return {
+        "attestation_id": "attestation_fixture",
+        "thread_id": THREAD,
+        "draft_id": DRAFT,
+        "delay_seconds": 20,
+        "superhuman_id": SID,
+        "account": ACCOUNT,
+        "fingerprint": {"exact": "sha256:approved"},
+    }
+
+
+def _state(name, *, provider_id=None):
+    return {
+        "account": ACCOUNT,
+        "thread_id": THREAD,
+        "draft_id": DRAFT,
+        "state": name,
+        "terminal": name in lifecycle.TERMINAL_STATES,
+        "send_blocked": name in lifecycle.BLOCKING_STATES,
+        "outbound_evidence": name == lifecycle.PROVIDER_CONFIRMED,
+        "confidence": "fixture",
+        "consistency": "matched",
+        "timestamps": {
+            "sent_at": "2026-07-10T12:00:00Z" if name in {lifecycle.BACKEND_CONFIRMED, lifecycle.PROVIDER_CONFIRMED} else None,
+            "provider_message_at": "2026-07-10T12:00:01Z" if name == lifecycle.PROVIDER_CONFIRMED else None,
+        },
+        "provider_message": {"id": provider_id} if provider_id else None,
+    }
+
+
+def _observe(state):
+    return state, {"draft": {}}, []
+
+
+def _preflight():
+    return {
+        "draft": {"id": DRAFT, "threadId": THREAD},
+        "lifecycle": {"account": ACCOUNT},
+        "warnings": [],
+    }
+
+
+def _run(journal, state, *, post_side_effect=None, wait=0):
+    with patch("superhuman_mail.send._preflight", return_value=_preflight()):
+        with patch("superhuman_mail.send._attestation.load", return_value=_record()):
+            with patch("superhuman_mail.send._attestation.verify"):
+                with patch("superhuman_mail.send._attestation.revalidate_for_send", return_value={"outgoing_payload": {"fixture": True}}):
+                    with patch("superhuman_mail.send.lifecycle.resolve_account", return_value=(ACCOUNT, [])):
+                        with patch("superhuman_mail.send.lifecycle.observe", return_value=_observe(state)):
+                            with patch("superhuman_mail.send._post_exact_payload", side_effect=post_side_effect) as post:
+                                result = send.execute(
+                                    THREAD,
+                                    DRAFT,
+                                    account=ACCOUNT["email"],
+                                    attestation="attestation_fixture",
+                                    approval_ref="approval_fixture",
+                                    wait=wait,
+                                    journal=journal,
+                                )
+    return result, post
+
+
+def test_stale_second_probe_never_creates_or_strands_attempt(tmp_path):
+    from superhuman_mail.attestation import AttestationError
+
+    journal = AttemptJournal(tmp_path / "attempts.sqlite3")
+    with patch("superhuman_mail.send._preflight", return_value=_preflight()):
+        with patch("superhuman_mail.send._attestation.load", return_value=_record()):
+            with patch("superhuman_mail.send._attestation.verify"):
+                with patch(
+                    "superhuman_mail.send._attestation.revalidate_for_send",
+                    side_effect=AttestationError("STALE_ATTESTATION", "changed"),
+                ):
+                    with patch("superhuman_mail.send.lifecycle.resolve_account", return_value=(ACCOUNT, [])):
+                        with patch("superhuman_mail.send._post_exact_payload") as post:
+                            result = send.execute(
+                                THREAD,
+                                DRAFT,
+                                account=ACCOUNT["email"],
+                                attestation="attestation_fixture",
+                                approval_ref="approval_fixture",
+                                wait=0,
+                                journal=journal,
+                            )
+    assert result["status"] == "failed"
+    assert result["errors"][0]["code"] == "STALE_ATTESTATION"
+    assert journal.get(ACCOUNT["provider_user_id"], DRAFT) is None
+    post.assert_not_called()
+
+
+def test_http_acceptance_during_undo_window_is_pending_not_sent(tmp_path):
+    journal = AttemptJournal(tmp_path / "attempts.sqlite3")
+    result, post = _run(journal, _state(lifecycle.PENDING_UNDO))
+    assert post.call_count == 1
+    assert result["status"] == "succeeded"
+    assert result["data"]["state"] == lifecycle.PENDING_UNDO
+    assert result["data"]["accepted"] is True
+    assert result["data"]["sent"] is False
+    assert result["data"]["provider_confirmed"] is False
+    assert result["data"]["idempotency_scope"] == "local_cooperating_processes"
+
+
+def test_provider_confirmation_is_only_sent_success(tmp_path):
+    journal = AttemptJournal(tmp_path / "attempts.sqlite3")
+    result, post = _run(journal, _state(lifecycle.PROVIDER_CONFIRMED, provider_id="message_fixture"))
+    assert post.call_count == 1
+    assert result["status"] == "succeeded"
+    assert result["data"]["state"] == lifecycle.PROVIDER_CONFIRMED
+    assert result["data"]["sent"] is True
+    assert result["data"]["provider_confirmed"] is True
+    assert result["data"]["provider_message_id"] == "message_fixture"
+
+
+def test_retry_reconciles_existing_attempt_without_second_probe_or_post(tmp_path):
+    journal = AttemptJournal(tmp_path / "attempts.sqlite3")
+    state = _state(lifecycle.PROVIDER_CONFIRMED, provider_id="message_fixture")
+    result, first_post = _run(journal, state)
+    assert result["data"]["sent"] is True
+    assert first_post.call_count == 1
+
+    with patch("superhuman_mail.send._preflight") as preflight:
+        with patch("superhuman_mail.send._attestation.load", return_value=_record()):
+            with patch("superhuman_mail.send._attestation.verify"):
+                with patch("superhuman_mail.send._attestation.revalidate_for_send") as probe:
+                    with patch("superhuman_mail.send.lifecycle.resolve_account", return_value=(ACCOUNT, [])):
+                        with patch("superhuman_mail.send.lifecycle.observe", return_value=_observe(state)):
+                            with patch("superhuman_mail.send._post_exact_payload") as second_post:
+                                retried = send.execute(
+                                    THREAD,
+                                    DRAFT,
+                                    account=ACCOUNT["email"],
+                                    attestation="attestation_fixture",
+                                    approval_ref="approval_fixture",
+                                    wait=0,
+                                    journal=journal,
+                                )
+    assert retried["data"]["sent"] is True
+    second_post.assert_not_called()
+    probe.assert_not_called()
+    preflight.assert_not_called()
+    assert journal.get(ACCOUNT["provider_user_id"], DRAFT)["post_count"] == 1
+
+
+def test_recorded_provider_confirmation_is_not_downgraded_by_stale_cache(tmp_path):
+    journal = AttemptJournal(tmp_path / "attempts.sqlite3")
+    confirmed = _state(lifecycle.PROVIDER_CONFIRMED, provider_id="message_fixture")
+    first, _post = _run(journal, confirmed)
+    assert first["data"]["sent"] is True
+
+    with patch("superhuman_mail.send._preflight") as preflight:
+        with patch("superhuman_mail.send._attestation.load", return_value=_record()):
+            with patch("superhuman_mail.send._attestation.verify"):
+                with patch("superhuman_mail.send.lifecycle.resolve_account", return_value=(ACCOUNT, [])):
+                    with patch("superhuman_mail.send.lifecycle.observe", return_value=_observe(_state(lifecycle.ACTIVE))):
+                        with patch("superhuman_mail.send._post_exact_payload") as post:
+                            result = send.execute(
+                                THREAD,
+                                DRAFT,
+                                account=ACCOUNT["email"],
+                                attestation="attestation_fixture",
+                                approval_ref="approval_fixture",
+                                wait=0,
+                                journal=journal,
+                            )
+    assert result["status"] == "succeeded"
+    assert result["data"]["sent"] is True
+    assert result["data"]["state"] == lifecycle.PROVIDER_CONFIRMED
+    assert result["data"]["lifecycle"]["consistency"] == "observation_lag"
+    preflight.assert_not_called()
+    post.assert_not_called()
+
+
+def test_lost_http_response_reconciles_provider_and_never_reposts(tmp_path):
+    journal = AttemptJournal(tmp_path / "attempts.sqlite3")
+    result, post = _run(
+        journal,
+        _state(lifecycle.PROVIDER_CONFIRMED, provider_id="message_fixture"),
+        post_side_effect=urllib.error.URLError("connection reset"),
+    )
+    assert post.call_count == 1
+    assert result["status"] == "succeeded"
+    assert result["data"]["sent"] is True
+    stored = journal.get(ACCOUNT["provider_user_id"], DRAFT)
+    assert stored["post_count"] == 1
+    assert stored["response_class"] == "UNREACHABLE"
+
+
+def test_unknown_outcome_remains_non_sent_and_cannot_claim_again(tmp_path):
+    journal = AttemptJournal(tmp_path / "attempts.sqlite3")
+    result, post = _run(journal, _state(lifecycle.ACTIVE), post_side_effect=urllib.error.URLError("reset"))
+    assert post.call_count == 1
+    assert result["status"] == "succeeded"
+    assert result["data"]["sent"] is False
+    assert result["data"]["state"] == "unknown"
+    stored = journal.get(ACCOUNT["provider_user_id"], DRAFT)
+    assert stored["state"] == "unknown"
+    _row, claimed = journal.claim_post(stored["attempt_id"])
+    assert claimed is False
+
+
+def test_future_scheduled_job_is_success_without_sent_claim(tmp_path):
+    journal = AttemptJournal(tmp_path / "attempts.sqlite3")
+    result, _post = _run(journal, _state(lifecycle.SCHEDULED))
+    assert result["status"] == "succeeded"
+    assert result["data"]["state"] == lifecycle.SCHEDULED
+    assert result["data"]["sent"] is False
+
+
+def test_concurrent_local_callers_share_one_post_claim(tmp_path):
+    journal_path = tmp_path / "attempts.sqlite3"
+    counter = 0
+    lock = threading.Lock()
+
+    def post(_payload, *, delay):
+        nonlocal counter
+        with lock:
+            counter += 1
+
+    def call():
+        journal = AttemptJournal(journal_path)
+        return send.execute(
+            THREAD,
+            DRAFT,
+            account=ACCOUNT["email"],
+            attestation="attestation_fixture",
+            approval_ref="approval_fixture",
+            wait=0,
+            journal=journal,
+        )
+
+    # Patch once around both workers so the synthetic transport remains stable
+    # while SQLite arbitrates the real cross-connection claim.
+    with patch("superhuman_mail.send._preflight", return_value=_preflight()):
+        with patch("superhuman_mail.send._attestation.load", return_value=_record()):
+            with patch("superhuman_mail.send._attestation.verify"):
+                with patch("superhuman_mail.send._attestation.revalidate_for_send", return_value={"outgoing_payload": {"fixture": True}}):
+                    with patch("superhuman_mail.send.lifecycle.resolve_account", return_value=(ACCOUNT, [])):
+                        with patch("superhuman_mail.send.lifecycle.observe", return_value=_observe(_state(lifecycle.PROVIDER_CONFIRMED, provider_id="message_fixture"))):
+                            with patch("superhuman_mail.send._post_exact_payload", side_effect=post):
+                                with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+                                    results = list(pool.map(lambda _index: call(), range(2)))
+    assert counter == 1
+    assert all(result["status"] == "succeeded" for result in results)
+    assert journal_path.exists()
+    assert AttemptJournal(journal_path).get(ACCOUNT["provider_user_id"], DRAFT)["post_count"] == 1

--- a/tests/test_send_attempt_flow.py
+++ b/tests/test_send_attempt_flow.py
@@ -6,7 +6,7 @@ import threading
 import urllib.error
 from unittest.mock import patch
 
-from superhuman_mail import lifecycle, send
+from superhuman_mail import attestation, lifecycle, send
 from superhuman_mail.attempts import AttemptJournal
 
 THREAD = "thread_fixture"
@@ -78,6 +78,35 @@ def _run(journal, state, *, post_side_effect=None, wait=0):
     return result, post
 
 
+def test_transport_posts_canonical_fresh_payload_bytes_only():
+    captured = {}
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return b"{}"
+
+    def urlopen(request, timeout):
+        captured["request"] = request
+        captured["timeout"] = timeout
+        return Response()
+
+    payload = {"html_body": "<p>exact</p>", "superhuman_id": SID, "headers": []}
+    with patch("superhuman_mail.send._auth.api_headers", return_value={"Authorization": "fixture"}):
+        with patch("superhuman_mail.send.urllib.request.urlopen", side_effect=urlopen):
+            send._post_exact_payload(payload, delay=20)
+    request = captured["request"]
+    expected = {"version": 3, "outgoing_message": payload, "delay": 20, "is_multi_recipient": True}
+    assert request.method == "POST"
+    assert request.data == attestation.canonical_bytes(expected)
+    assert captured["timeout"] == 30
+
+
 def test_stale_second_probe_never_creates_or_strands_attempt(tmp_path):
     from superhuman_mail.attestation import AttestationError
 
@@ -109,12 +138,15 @@ def test_stale_second_probe_never_creates_or_strands_attempt(tmp_path):
 def test_http_acceptance_during_undo_window_is_pending_not_sent(tmp_path):
     journal = AttemptJournal(tmp_path / "attempts.sqlite3")
     result, post = _run(journal, _state(lifecycle.PENDING_UNDO))
-    assert post.call_count == 1
+    post.assert_called_once_with({"fixture": True}, delay=20)
     assert result["status"] == "succeeded"
     assert result["data"]["state"] == lifecycle.PENDING_UNDO
     assert result["data"]["accepted"] is True
     assert result["data"]["sent"] is False
     assert result["data"]["provider_confirmed"] is False
+    assert result["data"]["approval_authority"] == "correlation_only"
+    assert result["data"]["approval_verified"] is False
+    assert result["data"]["unattended_send_eligible"] is False
     assert result["data"]["idempotency_scope"] == "local_cooperating_processes"
 
 
@@ -198,6 +230,7 @@ def test_lost_http_response_reconciles_provider_and_never_reposts(tmp_path):
     assert post.call_count == 1
     assert result["status"] == "succeeded"
     assert result["data"]["sent"] is True
+    assert result["data"]["accepted"] is True
     stored = journal.get(ACCOUNT["provider_user_id"], DRAFT)
     assert stored["post_count"] == 1
     assert stored["response_class"] == "UNREACHABLE"
@@ -210,10 +243,92 @@ def test_unknown_outcome_remains_non_sent_and_cannot_claim_again(tmp_path):
     assert result["status"] == "succeeded"
     assert result["data"]["sent"] is False
     assert result["data"]["state"] == "unknown"
+    assert result["data"]["post_claimed"] is True
+    assert result["data"]["accepted"] is False
     stored = journal.get(ACCOUNT["provider_user_id"], DRAFT)
     assert stored["state"] == "unknown"
     _row, claimed = journal.claim_post(stored["attempt_id"])
     assert claimed is False
+
+
+def test_status_does_not_brick_never_posted_prepared_attempt(tmp_path):
+    journal = AttemptJournal(tmp_path / "attempts.sqlite3")
+    prepared, _created = journal.create_or_get(
+        account_id=ACCOUNT["provider_user_id"],
+        account_hash="account-hash",
+        thread_id=THREAD,
+        draft_id=DRAFT,
+        attestation_id="attestation_fixture",
+        approval_ref="approval_fixture",
+        superhuman_id=SID,
+        outgoing_fingerprint="sha256:approved",
+    )
+    with patch("superhuman_mail.send.lifecycle.resolve_account", return_value=(ACCOUNT, [])):
+        with patch("superhuman_mail.send.lifecycle.observe", return_value=_observe(_state(lifecycle.ACTIVE))):
+            status = send.status(THREAD, DRAFT, account=ACCOUNT["email"], wait=120, journal=journal)
+    stored = journal.get_by_id(prepared["attempt_id"])
+    assert status["data"]["accepted"] is False
+    assert status["data"]["post_claimed"] is False
+    assert stored["state"] == "prepared"
+    assert stored["post_count"] == 0
+
+    result, post = _run(
+        journal,
+        _state(lifecycle.PROVIDER_CONFIRMED, provider_id="message_fixture"),
+    )
+    post.assert_called_once_with({"fixture": True}, delay=20)
+    assert result["data"]["sent"] is True
+
+
+def test_concurrent_prepared_rotation_surfaces_attempt_conflict_not_key_error(tmp_path):
+    journal = AttemptJournal(tmp_path / "attempts.sqlite3")
+    journal.create_or_get(
+        account_id=ACCOUNT["provider_user_id"],
+        account_hash="account-hash",
+        thread_id=THREAD,
+        draft_id=DRAFT,
+        attestation_id="attestation_fixture",
+        approval_ref="approval_fixture",
+        superhuman_id=SID,
+        outgoing_fingerprint="sha256:approved",
+    )
+    with patch("superhuman_mail.send._attestation.load", return_value=_record()):
+        with patch("superhuman_mail.send._attestation.verify"):
+            with patch("superhuman_mail.send._attestation.revalidate_for_send", return_value={"outgoing_payload": {"fixture": True}}):
+                with patch("superhuman_mail.send.lifecycle.resolve_account", return_value=(ACCOUNT, [])):
+                    with patch.object(journal, "claim_post", side_effect=KeyError("rotated")):
+                        with patch("superhuman_mail.send._post_exact_payload") as post:
+                            result = send.execute(
+                                THREAD,
+                                DRAFT,
+                                account=ACCOUNT["email"],
+                                attestation="attestation_fixture",
+                                approval_ref="approval_fixture",
+                                journal=journal,
+                            )
+    assert result["status"] == "failed"
+    assert result["errors"][0]["code"] == "ATTEMPT_CONFLICT"
+    post.assert_not_called()
+
+
+def test_status_rejects_thread_mismatch_for_existing_attempt(tmp_path):
+    journal = AttemptJournal(tmp_path / "attempts.sqlite3")
+    journal.create_or_get(
+        account_id=ACCOUNT["provider_user_id"],
+        account_hash="account-hash",
+        thread_id=THREAD,
+        draft_id=DRAFT,
+        attestation_id="attestation_fixture",
+        approval_ref="approval_fixture",
+        superhuman_id=SID,
+        outgoing_fingerprint="sha256:approved",
+    )
+    with patch("superhuman_mail.send.lifecycle.resolve_account", return_value=(ACCOUNT, [])):
+        with patch("superhuman_mail.send.lifecycle.observe") as observe:
+            result = send.status("wrong-thread", DRAFT, account=ACCOUNT["email"], journal=journal)
+    assert result["status"] == "failed"
+    assert result["errors"][0]["code"] == "ATTEMPT_THREAD_MISMATCH"
+    observe.assert_not_called()
 
 
 def test_status_without_local_attempt_waits_for_native_job_provider_confirmation(tmp_path):

--- a/tests/test_send_safety.py
+++ b/tests/test_send_safety.py
@@ -62,7 +62,7 @@ def _observed(state=lifecycle.ACTIVE, *, draft=None):
 def test_validate_and_execute_block_non_active_lifecycle_before_transport(state, code):
     with patch("superhuman_mail.send.lifecycle.observe", return_value=_observed(state)):
         with patch("superhuman_mail.send.urllib.request.urlopen") as urlopen:
-            validated = send.validate(THREAD, DRAFT)
+            validated = send.validate(THREAD, DRAFT, account=ACCOUNT["email"])
             executed = send.execute(THREAD, DRAFT, account=ACCOUNT["email"])
     assert validated["status"] == "failed"
     assert validated["errors"][0]["code"] == code
@@ -91,7 +91,7 @@ def test_invalid_envelope_or_content_is_blocked_inside_execute(draft, code):
 
 def test_empty_subject_requires_explicit_exact_attestation_policy():
     with patch("superhuman_mail.send.lifecycle.observe", return_value=_observed(draft=_draft(subject=""))):
-        validated = send.validate(THREAD, DRAFT)
+        validated = send.validate(THREAD, DRAFT, account=ACCOUNT["email"])
         executed = send.execute(THREAD, DRAFT, account=ACCOUNT["email"])
     assert validated["errors"][0]["code"] == "SUBJECT_REQUIRED"
     assert executed["errors"][0]["code"] == "ATTESTATION_REQUIRED"
@@ -99,11 +99,14 @@ def test_empty_subject_requires_explicit_exact_attestation_policy():
 
 def test_validate_is_truthful_about_metadata_only_preflight():
     with patch("superhuman_mail.send.lifecycle.observe", return_value=_observed()):
-        result = send.validate(THREAD, DRAFT)
+        result = send.validate(THREAD, DRAFT, account=ACCOUNT["email"])
     assert result["status"] == "succeeded"
     assert result["data"]["sendable"] is True
     assert result["data"]["send_eligible"] is False
     assert result["data"]["render_attested"] is False
+    assert result["data"]["approval_authority"] == "correlation_only"
+    assert result["data"]["approval_verified"] is False
+    assert result["data"]["unattended_send_eligible"] is False
     assert result["data"]["lifecycle"]["state"] == lifecycle.ACTIVE
 
 
@@ -116,6 +119,26 @@ class _Response:
 
     def read(self):
         return b"{}"
+
+
+def test_validate_requires_explicit_account_binding():
+    result = send.validate(THREAD, DRAFT)
+    assert result["status"] == "failed"
+    assert result["errors"][0]["code"] == "ACCOUNT_REQUIRED"
+
+
+def test_execute_rejects_blank_approval_reference_before_attestation_load():
+    with patch("superhuman_mail.send._attestation.load") as load:
+        result = send.execute(
+            THREAD,
+            DRAFT,
+            account=ACCOUNT["email"],
+            attestation="fixture",
+            approval_ref="   ",
+        )
+    assert result["status"] == "failed"
+    assert result["errors"][0]["code"] == "APPROVAL_REFERENCE_REQUIRED"
+    load.assert_not_called()
 
 
 def test_execute_requires_exact_attestation_before_transport():

--- a/tests/test_send_safety.py
+++ b/tests/test_send_safety.py
@@ -104,8 +104,9 @@ def test_validate_is_truthful_about_metadata_only_preflight():
     assert result["data"]["sendable"] is True
     assert result["data"]["send_eligible"] is False
     assert result["data"]["render_attested"] is False
-    assert result["data"]["approval_authority"] == "correlation_only"
+    assert result["data"]["approval_authority"] == "external_receipt_required"
     assert result["data"]["approval_verified"] is False
+    assert result["data"]["approval_consumed"] is False
     assert result["data"]["unattended_send_eligible"] is False
     assert result["data"]["lifecycle"]["state"] == lifecycle.ACTIVE
 
@@ -127,17 +128,18 @@ def test_validate_requires_explicit_account_binding():
     assert result["errors"][0]["code"] == "ACCOUNT_REQUIRED"
 
 
-def test_execute_rejects_blank_approval_reference_before_attestation_load():
+def test_caller_controlled_approval_reference_cannot_authorize_before_load():
     with patch("superhuman_mail.send._attestation.load") as load:
         result = send.execute(
             THREAD,
             DRAFT,
             account=ACCOUNT["email"],
             attestation="fixture",
-            approval_ref="   ",
+            approval_ref="caller-invented",
         )
     assert result["status"] == "failed"
-    assert result["errors"][0]["code"] == "APPROVAL_REFERENCE_REQUIRED"
+    assert result["errors"][0]["code"] == "APPROVAL_RECEIPT_REQUIRED"
+    assert "audit-only" in result["errors"][0]["hint"]
     load.assert_not_called()
 
 

--- a/tests/test_send_safety.py
+++ b/tests/test_send_safety.py
@@ -1,0 +1,127 @@
+"""Execute-time send guard regression tests; all transports are fake."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from superhuman_mail import lifecycle, send
+
+THREAD = "thread_fixture"
+DRAFT = "draft_fixture"
+ACCOUNT = {"email": "owner@example.test", "provider_user_id": "user-fixture"}
+
+
+def _draft(**overrides):
+    value = {
+        "id": DRAFT,
+        "threadId": THREAD,
+        "action": "reply",
+        "from": {"email": ACCOUNT["email"]},
+        "to": [{"email": "recipient@example.test"}],
+        "cc": [],
+        "bcc": [],
+        "subject": "Fixture",
+        "body": "<div>Hello</div>",
+        "attachments": [],
+        "rfc822Id": "<fixture@example.test>",
+    }
+    value.update(overrides)
+    return value
+
+
+def _observed(state=lifecycle.ACTIVE, *, draft=None):
+    lifecycle_data = {
+        "account": ACCOUNT,
+        "thread_id": THREAD,
+        "draft_id": DRAFT,
+        "state": state,
+        "terminal": state in lifecycle.TERMINAL_STATES,
+        "send_blocked": state in lifecycle.BLOCKING_STATES,
+        "outbound_evidence": state == lifecycle.PROVIDER_CONFIRMED,
+        "confidence": "fixture",
+        "consistency": "matched",
+    }
+    return lifecycle_data, {"draft": draft or _draft()}, []
+
+
+@pytest.mark.parametrize(
+    ("state", "code"),
+    [
+        (lifecycle.PROVIDER_CONFIRMED, "DRAFT_ALREADY_SENT"),
+        (lifecycle.BACKEND_CONFIRMED, "DRAFT_ALREADY_SENT"),
+        (lifecycle.DISCARDED, "DRAFT_DISCARDED"),
+        (lifecycle.SCHEDULED, "SEND_ALREADY_PENDING"),
+        (lifecycle.REQUESTED, "SEND_ALREADY_PENDING"),
+        (lifecycle.PENDING_UNDO, "SEND_ALREADY_PENDING"),
+        (lifecycle.FAILED, "TERMINAL_SEND_JOB"),
+        (lifecycle.ABORTED, "TERMINAL_SEND_JOB"),
+        (lifecycle.INCONSISTENT, "LIFECYCLE_INCONSISTENT"),
+    ],
+)
+def test_validate_and_execute_block_non_active_lifecycle_before_transport(state, code):
+    with patch("superhuman_mail.send.lifecycle.observe", return_value=_observed(state)):
+        with patch("superhuman_mail.send.urllib.request.urlopen") as urlopen:
+            validated = send.validate(THREAD, DRAFT)
+            executed = send.execute(THREAD, DRAFT, account=ACCOUNT["email"])
+    assert validated["status"] == "failed"
+    assert validated["errors"][0]["code"] == code
+    assert executed["status"] == "failed"
+    assert executed["errors"][0]["code"] == code
+    urlopen.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("draft", "code"),
+    [
+        (_draft(to=[], cc=[], bcc=[]), "RECIPIENTS_REQUIRED"),
+        (_draft(to=[{"email": "not an address"}]), "INVALID_RECIPIENT"),
+        (_draft(body="<div><br></div>"), "BODY_REQUIRED"),
+        (_draft(**{"from": {"email": "wrong@example.test"}}), "FROM_ACCOUNT_MISMATCH"),
+    ],
+)
+def test_invalid_envelope_or_content_is_blocked_inside_execute(draft, code):
+    with patch("superhuman_mail.send.lifecycle.observe", return_value=_observed(draft=draft)):
+        with patch("superhuman_mail.send.urllib.request.urlopen") as urlopen:
+            result = send.execute(THREAD, DRAFT, account=ACCOUNT["email"])
+    assert result["status"] == "failed"
+    assert result["errors"][0]["code"] == code
+    urlopen.assert_not_called()
+
+
+def test_empty_subject_requires_explicit_exact_attestation_policy():
+    with patch("superhuman_mail.send.lifecycle.observe", return_value=_observed(draft=_draft(subject=""))):
+        validated = send.validate(THREAD, DRAFT)
+        executed = send.execute(THREAD, DRAFT, account=ACCOUNT["email"])
+    assert validated["errors"][0]["code"] == "SUBJECT_REQUIRED"
+    assert executed["errors"][0]["code"] == "ATTESTATION_REQUIRED"
+
+
+def test_validate_is_truthful_about_metadata_only_preflight():
+    with patch("superhuman_mail.send.lifecycle.observe", return_value=_observed()):
+        result = send.validate(THREAD, DRAFT)
+    assert result["status"] == "succeeded"
+    assert result["data"]["sendable"] is True
+    assert result["data"]["send_eligible"] is False
+    assert result["data"]["render_attested"] is False
+    assert result["data"]["lifecycle"]["state"] == lifecycle.ACTIVE
+
+
+class _Response:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self):
+        return b"{}"
+
+
+def test_execute_requires_exact_attestation_before_transport():
+    with patch("superhuman_mail.send.lifecycle.observe", return_value=_observed()):
+        with patch("superhuman_mail.send.urllib.request.urlopen") as urlopen:
+            result = send.execute(THREAD, DRAFT, account=ACCOUNT["email"])
+    assert result["status"] == "failed"
+    assert result["errors"][0]["code"] == "ATTESTATION_REQUIRED"
+    urlopen.assert_not_called()

--- a/tests/test_smart_send.py
+++ b/tests/test_smart_send.py
@@ -85,10 +85,10 @@ class TestBuildOutgoing:
         out = _build_outgoing(draft)
         assert out["scheduled_for"] == "2026-04-01T09:00:00Z"
 
-    def test_reminder_propagates(self):
+    def test_reminder_stays_on_persisted_draft_not_current_send_request(self):
         draft = self._minimal_draft(reminder="2026-04-03T09:00:00Z")
         out = _build_outgoing(draft)
-        assert out["reminder"] == "2026-04-03T09:00:00Z"
+        assert "reminder" not in out
 
     def test_sensitivity_labels_propagate(self):
         draft = self._minimal_draft(sensitivityLabelId="lbl_123", sensitivityTenantId="ten_456")


### PR DESCRIPTION
## Summary

Implements the approved lifecycle/render design from #33 end to end:

- canonical per-draft lifecycle/provenance joined across userdata wrapper, send job, and immutable provider message
- mandatory execute-time terminal/discarded/pending/invalid/empty guard
- truthful requested/scheduled/backend/provider-confirmed states and exit `4` for pending/unknown
- canonical private SQLite attempt journal, stable send identity, atomic local one-POST claim, and reconcile-before-retry behavior
- signed, expiring exact live-Superhuman renderer attestations
- mandatory post-grace second no-write renderer probe; only freshly probed bytes equal to approval may POST
- safe read-only `attestation show` contract for orchestration
- lifecycle-aware draft/status CLI, Python client updates, docs/skill/release notes

## Breaking send contract

`send --confirm` now requires:

```text
--account EMAIL --attestation ID_OR_PATH --approval-receipt RECEIPT.json
```

Only `sent_provider_confirmed` returns `sent: true`. Local idempotency is explicitly reported as `local_cooperating_processes`; no cross-host/native-UI exactly-once claim is made.

## Approval boundary

Caller-controlled `--approval-ref` never authorizes. Core now verifies `shm-approval-receipt/v1` Ed25519 receipts against non-caller-writable trust roots, binds them to the exact attestation/payload/envelope/render/schedule, and atomically consumes the receipt with the one POST claim. With no pinned external issuer, confirm fails closed; unattended execution still requires the separate credential-isolated trusted executor defined in the issuer contract.

Contract: `docs/approval-receipt-issuer-contract.md` + `docs/approval-receipt-v1.schema.json`.

## Cross-repo compatibility

- `pi-setup#18` at `31138ea7` is safe-held but not yet functional against this final receipt interface: it rejects `--approval-receipt` and accepts deprecated correlation refs; core still rejects the latter with `APPROVAL_RECEIPT_REQUIRED`. It must be updated before merge/enablement.
- `commercial#855` final evidence-only head `7ab156e7a03f5d46863f53ab4afa4b9af1ee5bc0` is typed-output compatible: its code diff is zero versus proven baseline `cf4888f3`; a real core provider-confirmed fixture preserved all approval/receipt/executor fields and passed its provider-only gate. The final delta is docs/references only, with 229 tests and clean review. `SEND_CONFIRM_ROLLOUT_HELD` remains required; its future confirm builder still needs the receipt/executor update.
- External Slack issuer and credential-isolated canonical executor remain separate held dependencies. No synthetic/live send was run.

## Validation

- `pytest -q` — **217 passed**
- focused Ruff pass — clean
- Pyright on all new safety modules — 0 errors
- Python compileall + `node --check` — clean
- wheel/sdist build — clean; bundled `renderer_probe.js` verified in wheel
- `git diff --check` — clean

### Real non-sending proof

Against an existing active fixture draft in Superhuman Desktop 1041.0.15 / web code 2026-07-09:

- exact live DraftModel/editor/BodyContent path attested successfully
- mandatory second probe reproduced the same complete exact fingerprint
- both probes captured compose/outgoing screenshots and observed zero prohibited network writes
- final server source snapshot remained byte-for-byte equal, active, undiscarded, and without a send job
- the known historical terminal-source shape now classifies provider-confirmed and `send --dry-run` rejects it with `DRAFT_ALREADY_SENT`

During exploratory setup, one mis-grounded UI input briefly autosaved a one-character recipient token. Testing stopped; the complete saved pre-test server draft was restored byte-for-byte and independently re-read before the final two deterministic CDP probes. No send, schedule, comment, or other outbound action occurred.

## Safety notes

- strict renderer is version allowlisted and fails closed
- attachments require re-verifiable bytes or a stable digest
- private artifacts/journal are `0700`/`0600`; safe CLI inspection excludes bodies, addresses, subject text, signatures, provider-user ID, and reserved send identity
- provider confirmation is required before follow-up/CRM automation








